### PR TITLE
Stop search has failures matching street intersections in certain cases

### DIFF
--- a/lib/muni/direction.rb
+++ b/lib/muni/direction.rb
@@ -3,7 +3,14 @@ require "amatch"
 module Muni
   class Direction < Base
     def stop_at(place)
-      return stops.select{ |stop| stop.tag == place }.first if place =~ /[1-9][0-9]+/
+      if stop = stops.detect { |stop| stop.tag == place }
+        return stop
+      end
+
+      if stop = stops.detect { |stop| stop.title == place }
+        return stop
+      end
+
       pattern = Amatch::Sellers.new(place)
       stops.sort_by{ |stop|
         pattern.match(stop.title)

--- a/lib/muni/version.rb
+++ b/lib/muni/version.rb
@@ -1,3 +1,3 @@
 module Muni
-  VERSION = "0.0.5"
+  VERSION = "0.0.6"
 end

--- a/muni.gemspec
+++ b/muni.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |s|
   s.add_dependency "amatch"
   s.add_dependency "thor"   # For the executable
   s.add_development_dependency "rspec", "~> 2"
-  s.add_development_dependency "webmock"
+  s.add_development_dependency "webmock", "1.9.0"
   s.add_development_dependency "vcr"
 end

--- a/spec/cassettes/Muni_Direction/_stop_at/given_a_stop_tag/should_return_the_corresponding_stop.yml
+++ b/spec/cassettes/Muni_Direction/_stop_at/given_a_stop_tag/should_return_the_corresponding_stop.yml
@@ -1,0 +1,631 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://webservices.nextbus.com/service/publicXMLFeed?a=sf-muni&command=routeConfig&r=21
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - '*/*'
+      User-Agent:
+      - Ruby
+      Host:
+      - webservices.nextbus.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 Mar 2013 19:41:22 GMT
+      Server:
+      - Apache/2.2.4 (Unix) mod_ssl/2.2.4 OpenSSL/0.9.7m DAV/2 mod_jk/1.2.30
+      Access-Control-Allow-Origin:
+      - '*'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2235'
+      Content-Type:
+      - text/xml
+      X-Pad:
+      - avoid browser bug
+    body:
+      encoding: UTF-8
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\" ?> \n<body copyright=\"All
+        data copyright San Francisco Muni 2013.\">\n<route tag=\"21\" title=\"21-Hayes\"
+        color=\"660000\" oppositeColor=\"ffffff\" latMin=\"37.7729599\" latMax=\"37.7944299\"
+        lonMin=\"-122.46384\" lonMax=\"-122.39323\">\n<stop tag=\"6497\" title=\"Steuart
+        St &amp; Mission St\" lat=\"37.7933499\" lon=\"-122.39323\" stopId=\"16497\"/>\n<stop
+        tag=\"6501\" title=\"Steuart St &amp; Market St\" lat=\"37.7944299\" lon=\"-122.3945499\"
+        stopId=\"16501\"/>\n<stop tag=\"5669\" title=\"Market St &amp; Drumm St\"
+        lat=\"37.79347\" lon=\"-122.3961799\" stopId=\"15669\"/>\n<stop tag=\"5671\"
+        title=\"Market St &amp; Front St\" lat=\"37.79192\" lon=\"-122.3981499\" stopId=\"15671\"/>\n<stop
+        tag=\"5689\" title=\"Market St &amp; Sansome St\" lat=\"37.7901599\" lon=\"-122.40041\"
+        stopId=\"15689\"/>\n<stop tag=\"5684\" title=\"Market St &amp; Montgomery
+        St\" lat=\"37.7884899\" lon=\"-122.40248\" stopId=\"15684\"/>\n<stop tag=\"5674\"
+        title=\"Market St &amp; Grant Ave\" lat=\"37.78639\" lon=\"-122.4051599\"
+        stopId=\"15674\"/>\n<stop tag=\"5688\" title=\"Market St &amp; Powell St\"
+        lat=\"37.7846799\" lon=\"-122.40731\" stopId=\"15688\"/>\n<stop tag=\"5683\"
+        title=\"Market St &amp; Mason St\" lat=\"37.7828499\" lon=\"-122.40964\" stopId=\"15683\"/>\n<stop
+        tag=\"5656\" title=\"Market St &amp; 7th St North\" lat=\"37.7805699\" lon=\"-122.41244\"
+        stopId=\"15656\"/>\n<stop tag=\"7423\" title=\"Market St &amp; Hyde St\" lat=\"37.7787799\"
+        lon=\"-122.41472\" stopId=\"17423\"/>\n<stop tag=\"4997\" title=\"Hayes St
+        &amp; Larkin St\" lat=\"37.7777099\" lon=\"-122.41685\" stopId=\"14997\"/>\n<stop
+        tag=\"5013\" title=\"Hayes St &amp; Van Ness Ave\" lat=\"37.7772899\" lon=\"-122.42019\"
+        stopId=\"15013\"/>\n<stop tag=\"4996\" title=\"Hayes St &amp; Gough St\" lat=\"37.77689\"
+        lon=\"-122.4233299\" stopId=\"14996\"/>\n<stop tag=\"4998\" title=\"Hayes
+        St &amp; Laguna St\" lat=\"37.7765299\" lon=\"-122.42615\" stopId=\"14998\"/>\n<stop
+        tag=\"4983\" title=\"Hayes St &amp; Buchanan St\" lat=\"37.7762599\" lon=\"-122.42827\"
+        stopId=\"14983\"/>\n<stop tag=\"5014\" title=\"Hayes St &amp; Webster St\"
+        lat=\"37.7760599\" lon=\"-122.42988\" stopId=\"15014\"/>\n<stop tag=\"4993\"
+        title=\"Hayes St &amp; Fillmore St\" lat=\"37.77584\" lon=\"-122.4315599\"
+        stopId=\"14993\"/>\n<stop tag=\"5011\" title=\"Hayes St &amp; Steiner St\"
+        lat=\"37.77563\" lon=\"-122.4331999\" stopId=\"15011\"/>\n<stop tag=\"5003\"
+        title=\"Hayes St &amp; Pierce St\" lat=\"37.77547\" lon=\"-122.4344399\" stopId=\"15003\"/>\n<stop
+        tag=\"4991\" title=\"Hayes St &amp; Divisadero St\" lat=\"37.7749899\" lon=\"-122.43818\"
+        stopId=\"14991\"/>\n<stop tag=\"4979\" title=\"Hayes St &amp; Baker St\" lat=\"37.7745699\"
+        lon=\"-122.4415\" stopId=\"14979\"/>\n<stop tag=\"4999\" title=\"Hayes St
+        &amp; Lyon St\" lat=\"37.77443\" lon=\"-122.4426299\" stopId=\"14999\"/>\n<stop
+        tag=\"4985\" title=\"Hayes St &amp; Central Ave\" lat=\"37.7742\" lon=\"-122.4442999\"
+        stopId=\"14985\"/>\n<stop tag=\"5001\" title=\"Hayes St &amp; Masonic Ave\"
+        lat=\"37.7739299\" lon=\"-122.44651\" stopId=\"15001\"/>\n<stop tag=\"4987\"
+        title=\"Hayes St &amp; Clayton St\" lat=\"37.7736099\" lon=\"-122.44917\"
+        stopId=\"14987\"/>\n<stop tag=\"5007\" title=\"Hayes St &amp; Shrader St\"
+        lat=\"37.7731699\" lon=\"-122.4525\" stopId=\"15007\"/>\n<stop tag=\"5009\"
+        title=\"Hayes St &amp; Stanyan St\" lat=\"37.7729599\" lon=\"-122.45415\"
+        stopId=\"15009\"/>\n<stop tag=\"37499\" title=\"Fulton St &amp; Shrader St\"
+        lat=\"37.7748699\" lon=\"-122.45309\" stopId=\"137499\"/>\n<stop tag=\"7499\"
+        title=\"Fulton St &amp; Shrader St\" lat=\"37.7748699\" lon=\"-122.45309\"
+        stopId=\"17499\"/>\n<stop tag=\"7561\" title=\"Hayes St &amp; Shrader St\"
+        lat=\"37.77306\" lon=\"-122.4525099\" stopId=\"17561\"/>\n<stop tag=\"4988\"
+        title=\"Hayes St &amp; Clayton St\" lat=\"37.7734199\" lon=\"-122.44946\"
+        stopId=\"14988\"/>\n<stop tag=\"5002\" title=\"Hayes St &amp; Masonic Ave\"
+        lat=\"37.7739499\" lon=\"-122.44568\" stopId=\"15002\"/>\n<stop tag=\"4986\"
+        title=\"Hayes St &amp; Central Ave\" lat=\"37.77409\" lon=\"-122.4445099\"
+        stopId=\"14986\"/>\n<stop tag=\"5000\" title=\"Hayes St &amp; Lyon St\" lat=\"37.7742899\"
+        lon=\"-122.44286\" stopId=\"15000\"/>\n<stop tag=\"4980\" title=\"Hayes St
+        &amp; Baker St\" lat=\"37.7745099\" lon=\"-122.44126\" stopId=\"14980\"/>\n<stop
+        tag=\"4992\" title=\"Hayes St &amp; Divisadero St\" lat=\"37.7749999\" lon=\"-122.4374\"
+        stopId=\"14992\"/>\n<stop tag=\"5004\" title=\"Hayes St &amp; Pierce St\"
+        lat=\"37.7754099\" lon=\"-122.43418\" stopId=\"15004\"/>\n<stop tag=\"5012\"
+        title=\"Hayes St &amp; Steiner St\" lat=\"37.77563\" lon=\"-122.4324799\"
+        stopId=\"15012\"/>\n<stop tag=\"4994\" title=\"Hayes St &amp; Fillmore St\"
+        lat=\"37.7757999\" lon=\"-122.43083\" stopId=\"14994\"/>\n<stop tag=\"5015\"
+        title=\"Hayes St &amp; Webster St\" lat=\"37.7760399\" lon=\"-122.42919\"
+        stopId=\"15015\"/>\n<stop tag=\"4984\" title=\"Hayes St &amp; Buchanan St\"
+        lat=\"37.77624\" lon=\"-122.4275499\" stopId=\"14984\"/>\n<stop tag=\"5260\"
+        title=\"Laguna St &amp; Hayes St\" lat=\"37.7767499\" lon=\"-122.42627\" stopId=\"15260\"/>\n<stop
+        tag=\"4921\" title=\"Grove St &amp; Laguna St\" lat=\"37.77738\" lon=\"-122.4263199\"
+        stopId=\"14921\"/>\n<stop tag=\"4920\" title=\"Grove St &amp; Gough St\" lat=\"37.77775\"
+        lon=\"-122.4233099\" stopId=\"14920\"/>\n<stop tag=\"4923\" title=\"Grove
+        St &amp; Van Ness Ave\" lat=\"37.7781899\" lon=\"-122.41974\" stopId=\"14923\"/>\n<stop
+        tag=\"7463\" title=\"Grove St &amp; Polk St\" lat=\"37.77838\" lon=\"-122.4183099\"
+        stopId=\"17463\"/>\n<stop tag=\"5652\" title=\"Market St &amp; 9th St\" lat=\"37.77741\"
+        lon=\"-122.4163399\" stopId=\"15652\"/>\n<stop tag=\"5651\" title=\"Market
+        St &amp; 8th St\" lat=\"37.77861\" lon=\"-122.4148299\" stopId=\"15651\"/>\n<stop
+        tag=\"5650\" title=\"Market St &amp; 7th St\" lat=\"37.7803599\" lon=\"-122.41261\"
+        stopId=\"15650\"/>\n<stop tag=\"5647\" title=\"Market St &amp; 6th St\" lat=\"37.7820999\"
+        lon=\"-122.4104\" stopId=\"15647\"/>\n<stop tag=\"5645\" title=\"Market St
+        &amp; 5th St\" lat=\"37.7838899\" lon=\"-122.40814\" stopId=\"15645\"/>\n<stop
+        tag=\"5643\" title=\"Market St &amp; 4th St\" lat=\"37.7856499\" lon=\"-122.40589\"
+        stopId=\"15643\"/>\n<stop tag=\"5640\" title=\"Market St &amp; 3rd St\" lat=\"37.7875299\"
+        lon=\"-122.40352\" stopId=\"15640\"/>\n<stop tag=\"5685\" title=\"Market St
+        &amp; New Montgomery St\" lat=\"37.7886099\" lon=\"-122.40216\" stopId=\"15685\"/>\n<stop
+        tag=\"7264\" title=\"Market St &amp; 1st St\" lat=\"37.79094\" lon=\"-122.3991899\"
+        stopId=\"17264\"/>\n<stop tag=\"5658\" title=\"Market St &amp; Beale St\"
+        lat=\"37.79257\" lon=\"-122.3970199\" stopId=\"15658\"/>\n<stop tag=\"6475\"
+        title=\"Spear St &amp; Market St\" lat=\"37.7935899\" lon=\"-122.3955499\"
+        stopId=\"16475\"/>\n<stop tag=\"36497\" title=\"Steuart St &amp; Mission St\"
+        lat=\"37.7933499\" lon=\"-122.39323\" stopId=\"136497\"/>\n<stop tag=\"4733\"
+        title=\"Fulton St &amp; 6th Ave\" lat=\"37.7735299\" lon=\"-122.46384\" stopId=\"14733\"/>\n<stop
+        tag=\"3089\" title=\"Beale St &amp; Mission St\" lat=\"37.7917499\" lon=\"-122.3967\"
+        stopId=\"13089\"/>\n<direction tag=\"21_IB1\" title=\"Inbound to Downtown\"
+        name=\"Inbound\" useForUI=\"true\">\n  <stop tag=\"7499\" />\n  <stop tag=\"7561\"
+        />\n  <stop tag=\"4988\" />\n  <stop tag=\"5002\" />\n  <stop tag=\"4986\"
+        />\n  <stop tag=\"5000\" />\n  <stop tag=\"4980\" />\n  <stop tag=\"4992\"
+        />\n  <stop tag=\"5004\" />\n  <stop tag=\"5012\" />\n  <stop tag=\"4994\"
+        />\n  <stop tag=\"5015\" />\n  <stop tag=\"4984\" />\n  <stop tag=\"5260\"
+        />\n  <stop tag=\"4921\" />\n  <stop tag=\"4920\" />\n  <stop tag=\"4923\"
+        />\n  <stop tag=\"7463\" />\n  <stop tag=\"5652\" />\n  <stop tag=\"5651\"
+        />\n  <stop tag=\"5650\" />\n  <stop tag=\"5647\" />\n  <stop tag=\"5645\"
+        />\n  <stop tag=\"5643\" />\n  <stop tag=\"5640\" />\n  <stop tag=\"5685\"
+        />\n  <stop tag=\"7264\" />\n  <stop tag=\"5658\" />\n  <stop tag=\"6475\"
+        />\n  <stop tag=\"36497\" />\n</direction>\n<direction tag=\"21_OB4\" title=\"Outbound
+        to Golden Gate Park\" name=\"Outbound\" useForUI=\"true\">\n  <stop tag=\"6497\"
+        />\n  <stop tag=\"6501\" />\n  <stop tag=\"5669\" />\n  <stop tag=\"5671\"
+        />\n  <stop tag=\"5689\" />\n  <stop tag=\"5684\" />\n  <stop tag=\"5674\"
+        />\n  <stop tag=\"5688\" />\n  <stop tag=\"5683\" />\n  <stop tag=\"5656\"
+        />\n  <stop tag=\"7423\" />\n  <stop tag=\"4997\" />\n  <stop tag=\"5013\"
+        />\n  <stop tag=\"4996\" />\n  <stop tag=\"4998\" />\n  <stop tag=\"4983\"
+        />\n  <stop tag=\"5014\" />\n  <stop tag=\"4993\" />\n  <stop tag=\"5011\"
+        />\n  <stop tag=\"5003\" />\n  <stop tag=\"4991\" />\n  <stop tag=\"4979\"
+        />\n  <stop tag=\"4999\" />\n  <stop tag=\"4985\" />\n  <stop tag=\"5001\"
+        />\n  <stop tag=\"4987\" />\n  <stop tag=\"5007\" />\n  <stop tag=\"5009\"
+        />\n  <stop tag=\"37499\" />\n</direction>\n<path>\n<point lat=\"37.775\"
+        lon=\"-122.4374\"/>\n<point lat=\"37.77541\" lon=\"-122.43418\"/>\n<point
+        lat=\"37.77563\" lon=\"-122.43248\"/>\n<point lat=\"37.7757999\" lon=\"-122.43083\"/>\n<point
+        lat=\"37.77604\" lon=\"-122.42919\"/>\n<point lat=\"37.77624\" lon=\"-122.42755\"/>\n<point
+        lat=\"37.77646\" lon=\"-122.42627\"/>\n<point lat=\"37.77675\" lon=\"-122.42627\"/>\n<point
+        lat=\"37.7773899\" lon=\"-122.42646\"/>\n<point lat=\"37.77738\" lon=\"-122.42632\"/>\n<point
+        lat=\"37.77775\" lon=\"-122.42331\"/>\n<point lat=\"37.77819\" lon=\"-122.41974\"/>\n</path>\n<path>\n<point
+        lat=\"37.77487\" lon=\"-122.45309\"/>\n<point lat=\"37.77496\" lon=\"-122.45299\"/>\n<point
+        lat=\"37.7731\" lon=\"-122.45262\"/>\n<point lat=\"37.77306\" lon=\"-122.45251\"/>\n<point
+        lat=\"37.77342\" lon=\"-122.44946\"/>\n<point lat=\"37.77395\" lon=\"-122.44568\"/>\n</path>\n<path>\n<point
+        lat=\"37.77819\" lon=\"-122.41974\"/>\n<point lat=\"37.77848\" lon=\"-122.41823\"/>\n<point
+        lat=\"37.77838\" lon=\"-122.41831\"/>\n<point lat=\"37.7768\" lon=\"-122.4179\"/>\n<point
+        lat=\"37.77654\" lon=\"-122.41751\"/>\n<point lat=\"37.77741\" lon=\"-122.41634\"/>\n<point
+        lat=\"37.77861\" lon=\"-122.41483\"/>\n<point lat=\"37.78036\" lon=\"-122.41261\"/>\n</path>\n<path>\n<point
+        lat=\"37.7856499\" lon=\"-122.40589\"/>\n<point lat=\"37.7875299\" lon=\"-122.40352\"/>\n<point
+        lat=\"37.78861\" lon=\"-122.40216\"/>\n</path>\n<path>\n<point lat=\"37.77393\"
+        lon=\"-122.44651\"/>\n<point lat=\"37.77361\" lon=\"-122.44917\"/>\n<point
+        lat=\"37.77317\" lon=\"-122.4525\"/>\n<point lat=\"37.77296\" lon=\"-122.45415\"/>\n<point
+        lat=\"37.7728899\" lon=\"-122.45428\"/>\n<point lat=\"37.77464\" lon=\"-122.45463\"/>\n<point
+        lat=\"37.7749\" lon=\"-122.45346\"/>\n<point lat=\"37.77487\" lon=\"-122.45309\"/>\n</path>\n<path>\n<point
+        lat=\"37.78036\" lon=\"-122.41261\"/>\n<point lat=\"37.7821\" lon=\"-122.4104\"/>\n<point
+        lat=\"37.78389\" lon=\"-122.40814\"/>\n<point lat=\"37.7856499\" lon=\"-122.40589\"/>\n</path>\n<path>\n<point
+        lat=\"37.77487\" lon=\"-122.45309\"/>\n<point lat=\"37.7731\" lon=\"-122.45262\"/>\n<point
+        lat=\"37.77306\" lon=\"-122.45251\"/>\n<point lat=\"37.77342\" lon=\"-122.44946\"/>\n<point
+        lat=\"37.77395\" lon=\"-122.44568\"/>\n</path>\n<path>\n<point lat=\"37.77499\"
+        lon=\"-122.43818\"/>\n<point lat=\"37.77457\" lon=\"-122.4415\"/>\n<point
+        lat=\"37.77443\" lon=\"-122.44263\"/>\n<point lat=\"37.7742\" lon=\"-122.4443\"/>\n<point
+        lat=\"37.77393\" lon=\"-122.44651\"/>\n</path>\n<path>\n<point lat=\"37.77729\"
+        lon=\"-122.42019\"/>\n<point lat=\"37.77689\" lon=\"-122.42333\"/>\n<point
+        lat=\"37.77653\" lon=\"-122.42615\"/>\n<point lat=\"37.77626\" lon=\"-122.42827\"/>\n<point
+        lat=\"37.77606\" lon=\"-122.42988\"/>\n<point lat=\"37.77584\" lon=\"-122.43156\"/>\n<point
+        lat=\"37.77563\" lon=\"-122.4332\"/>\n<point lat=\"37.77547\" lon=\"-122.43444\"/>\n<point
+        lat=\"37.77499\" lon=\"-122.43818\"/>\n</path>\n<path>\n<point lat=\"37.78468\"
+        lon=\"-122.40731\"/>\n<point lat=\"37.78285\" lon=\"-122.40964\"/>\n<point
+        lat=\"37.78057\" lon=\"-122.41244\"/>\n</path>\n<path>\n<point lat=\"37.78861\"
+        lon=\"-122.40216\"/>\n<point lat=\"37.79094\" lon=\"-122.39919\"/>\n<point
+        lat=\"37.79257\" lon=\"-122.39702\"/>\n<point lat=\"37.79378\" lon=\"-122.39563\"/>\n<point
+        lat=\"37.79359\" lon=\"-122.39555\"/>\n<point lat=\"37.79254\" lon=\"-122.39407\"/>\n<point
+        lat=\"37.79322\" lon=\"-122.39319\"/>\n<point lat=\"37.7933499\" lon=\"-122.39323\"/>\n</path>\n<path>\n<point
+        lat=\"37.7933499\" lon=\"-122.39323\"/>\n<point lat=\"37.79443\" lon=\"-122.39455\"/>\n<point
+        lat=\"37.7944699\" lon=\"-122.39476\"/>\n<point lat=\"37.79347\" lon=\"-122.39618\"/>\n<point
+        lat=\"37.79192\" lon=\"-122.39815\"/>\n<point lat=\"37.79016\" lon=\"-122.40041\"/>\n</path>\n<path>\n<point
+        lat=\"37.79016\" lon=\"-122.40041\"/>\n<point lat=\"37.78849\" lon=\"-122.40248\"/>\n<point
+        lat=\"37.78639\" lon=\"-122.40516\"/>\n<point lat=\"37.78468\" lon=\"-122.40731\"/>\n</path>\n<path>\n<point
+        lat=\"37.78861\" lon=\"-122.40216\"/>\n<point lat=\"37.7924\" lon=\"-122.39739\"/>\n<point
+        lat=\"37.79175\" lon=\"-122.3967\"/>\n</path>\n<path>\n<point lat=\"37.77353\"
+        lon=\"-122.46384\"/>\n<point lat=\"37.77487\" lon=\"-122.45309\"/>\n</path>\n<path>\n<point
+        lat=\"37.77395\" lon=\"-122.44568\"/>\n<point lat=\"37.77409\" lon=\"-122.44451\"/>\n<point
+        lat=\"37.77429\" lon=\"-122.44286\"/>\n<point lat=\"37.77451\" lon=\"-122.44126\"/>\n<point
+        lat=\"37.775\" lon=\"-122.4374\"/>\n</path>\n<path>\n<point lat=\"37.78057\"
+        lon=\"-122.41244\"/>\n<point lat=\"37.77878\" lon=\"-122.41472\"/>\n<point
+        lat=\"37.77779\" lon=\"-122.41593\"/>\n<point lat=\"37.77771\" lon=\"-122.41685\"/>\n<point
+        lat=\"37.77729\" lon=\"-122.42019\"/>\n</path>\n</route>\n</body>\n"
+    http_version: 
+  recorded_at: Tue, 26 Mar 2013 19:41:23 GMT
+- request:
+    method: get
+    uri: http://webservices.nextbus.com/service/publicXMLFeed?a=sf-muni&command=routeConfig&r=2424
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - '*/*'
+      User-Agent:
+      - Ruby
+      Host:
+      - webservices.nextbus.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 Mar 2013 19:47:39 GMT
+      Server:
+      - Apache/2.2.4 (Unix) mod_ssl/2.2.4 OpenSSL/0.9.7m DAV/2 mod_jk/1.2.30
+      Access-Control-Allow-Origin:
+      - '*'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '202'
+      Content-Type:
+      - text/xml
+      X-Pad:
+      - avoid browser bug
+    body:
+      encoding: UTF-8
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\" ?> \n<body copyright=\"All
+        data copyright San Francisco Muni 2013.\">\n<Error shouldRetry=\"false\">\n
+        \ Could not get route \"2424\" for agency tag \"sf-muni\". \nOne of the tags
+        could be bad.\n</Error>\n</body>\n"
+    http_version: 
+  recorded_at: Tue, 26 Mar 2013 19:47:39 GMT
+- request:
+    method: get
+    uri: http://webservices.nextbus.com/service/publicXMLFeed?a=sf-muni&command=routeConfig&r=24
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - '*/*'
+      User-Agent:
+      - Ruby
+      Host:
+      - webservices.nextbus.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 Mar 2013 19:47:56 GMT
+      Server:
+      - Apache/2.2.4 (Unix) mod_ssl/2.2.4 OpenSSL/0.9.7m DAV/2 mod_jk/1.2.30
+      Access-Control-Allow-Origin:
+      - '*'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4048'
+      Content-Type:
+      - text/xml
+      X-Pad:
+      - avoid browser bug
+    body:
+      encoding: UTF-8
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\" ?> \n<body copyright=\"All
+        data copyright San Francisco Muni 2013.\">\n<route tag=\"24\" title=\"24-Divisadero\"
+        color=\"996699\" oppositeColor=\"000000\" latMin=\"37.7340899\" latMax=\"37.7927199\"
+        lonMin=\"-122.44108\" lonMax=\"-122.39093\">\n<stop tag=\"3541\" title=\"30th
+        St &amp; Mission St\" lat=\"37.7423099\" lon=\"-122.42217\" stopId=\"13541\"/>\n<stop
+        tag=\"4157\" title=\"Cortland Ave &amp; Mission St\" lat=\"37.74085\" lon=\"-122.42251\"
+        stopId=\"14157\"/>\n<stop tag=\"4161\" title=\"Cortland Ave &amp; Prospect
+        Ave\" lat=\"37.7402\" lon=\"-122.42093\" stopId=\"14161\"/>\n<stop tag=\"4150\"
+        title=\"Cortland Ave &amp; Elsie St\" lat=\"37.7397\" lon=\"-122.41969\" stopId=\"14150\"/>\n<stop
+        tag=\"4146\" title=\"Cortland Ave &amp; Bocana St\" lat=\"37.7393099\" lon=\"-122.4187199\"
+        stopId=\"14146\"/>\n<stop tag=\"4143\" title=\"Cortland Ave &amp; Andover
+        St\" lat=\"37.7390399\" lon=\"-122.4165799\" stopId=\"14143\"/>\n<stop tag=\"4152\"
+        title=\"Cortland Ave &amp; Ellsworth St\" lat=\"37.73883\" lon=\"-122.41461\"
+        stopId=\"14152\"/>\n<stop tag=\"4154\" title=\"Cortland Ave &amp; Folsom St\"
+        lat=\"37.73892\" lon=\"-122.4134299\" stopId=\"14154\"/>\n<stop tag=\"4159\"
+        title=\"Cortland Ave &amp; Prentiss St\" lat=\"37.7395699\" lon=\"-122.41211\"
+        stopId=\"14159\"/>\n<stop tag=\"7213\" title=\"Cortland Ave &amp; Bronte St\"
+        lat=\"37.7397099\" lon=\"-122.4101699\" stopId=\"17213\"/>\n<stop tag=\"4148\"
+        title=\"Cortland Ave &amp; Bayshore Blvd\" lat=\"37.7395399\" lon=\"-122.4072\"
+        stopId=\"14148\"/>\n<stop tag=\"5093\" title=\"Industrial St &amp; Bayshore
+        Blvd\" lat=\"37.73794\" lon=\"-122.4067799\" stopId=\"15093\"/>\n<stop tag=\"5094\"
+        title=\"Industrial St &amp; Elmira St\" lat=\"37.73879\" lon=\"-122.4037299\"
+        stopId=\"15094\"/>\n<stop tag=\"5095\" title=\"Industrial St &amp; Palou Ave\"
+        lat=\"37.73955\" lon=\"-122.4010099\" stopId=\"15095\"/>\n<stop tag=\"5884\"
+        title=\"Palou Ave &amp; Rankin St\" lat=\"37.73825\" lon=\"-122.39853\" stopId=\"15884\"/>\n<stop
+        tag=\"5882\" title=\"Palou Ave &amp; Quint St\" lat=\"37.73722\" lon=\"-122.39672\"
+        stopId=\"15882\"/>\n<stop tag=\"5880\" title=\"Palou Ave &amp; Phelps St\"
+        lat=\"37.7360999\" lon=\"-122.3948099\" stopId=\"15880\"/>\n<stop tag=\"5878\"
+        title=\"Palou Ave &amp; Newhall St\" lat=\"37.7350299\" lon=\"-122.3926599\"
+        stopId=\"15878\"/>\n<stop tag=\"33141\" title=\"3rd St &amp; Palou Ave\" lat=\"37.7340899\"
+        lon=\"-122.39093\" stopId=\"133141\"/>\n<stop tag=\"5167\" title=\"Jackson
+        St &amp; Webster St\" lat=\"37.7927199\" lon=\"-122.43302\" stopId=\"15167\"/>\n<stop
+        tag=\"5147\" title=\"Jackson St &amp; Fillmore St\" lat=\"37.7925299\" lon=\"-122.43468\"
+        stopId=\"15147\"/>\n<stop tag=\"5162\" title=\"Jackson St &amp; Steiner St\"
+        lat=\"37.7923499\" lon=\"-122.43611\" stopId=\"15162\"/>\n<stop tag=\"5160\"
+        title=\"Jackson St &amp; Scott St\" lat=\"37.7919299\" lon=\"-122.43924\"
+        stopId=\"15160\"/>\n<stop tag=\"5145\" title=\"Jackson St &amp; Divisadero
+        St\" lat=\"37.79172\" lon=\"-122.4408899\" stopId=\"15145\"/>\n<stop tag=\"4413\"
+        title=\"Divisadero St &amp; Clay St\" lat=\"37.7899699\" lon=\"-122.4408899\"
+        stopId=\"14413\"/>\n<stop tag=\"4410\" title=\"Divisadero St &amp; California
+        St\" lat=\"37.7879899\" lon=\"-122.4404999\" stopId=\"14410\"/>\n<stop tag=\"4433\"
+        title=\"Divisadero St &amp; Pine St\" lat=\"37.7869999\" lon=\"-122.4403199\"
+        stopId=\"14433\"/>\n<stop tag=\"4435\" title=\"Divisadero St &amp; Sutter
+        St\" lat=\"37.7851499\" lon=\"-122.43994\" stopId=\"14435\"/>\n<stop tag=\"4422\"
+        title=\"Divisadero St &amp; Geary Blvd\" lat=\"37.78316\" lon=\"-122.43953\"
+        stopId=\"14422\"/>\n<stop tag=\"4415\" title=\"Divisadero St &amp; Eddy St\"
+        lat=\"37.7804499\" lon=\"-122.43898\" stopId=\"14415\"/>\n<stop tag=\"4429\"
+        title=\"Divisadero St &amp; McAllister St\" lat=\"37.77768\" lon=\"-122.43841\"
+        stopId=\"14429\"/>\n<stop tag=\"4426\" title=\"Divisadero St &amp; Hayes St\"
+        lat=\"37.77489\" lon=\"-122.43786\" stopId=\"14426\"/>\n<stop tag=\"4432\"
+        title=\"Divisadero St &amp; Oak St\" lat=\"37.77305\" lon=\"-122.43749\" stopId=\"14432\"/>\n<stop
+        tag=\"4424\" title=\"Divisadero St &amp; Haight St\" lat=\"37.7710499\" lon=\"-122.4371\"
+        stopId=\"14424\"/>\n<stop tag=\"4330\" title=\"Castro St &amp; Duboce Ave\"
+        lat=\"37.76918\" lon=\"-122.4359599\" stopId=\"14330\"/>\n<stop tag=\"4308\"
+        title=\"Castro St &amp; 14th St\" lat=\"37.7674199\" lon=\"-122.4357099\"
+        stopId=\"14308\"/>\n<stop tag=\"4309\" title=\"Castro St &amp; 15th St\" lat=\"37.76583\"
+        lon=\"-122.43557\" stopId=\"14309\"/>\n<stop tag=\"4312\" title=\"Castro St
+        &amp; 16th St\" lat=\"37.76427\" lon=\"-122.43544\" stopId=\"14312\"/>\n<stop
+        tag=\"4334\" title=\"Castro St &amp; Market St\" lat=\"37.76214\" lon=\"-122.43519\"
+        stopId=\"14334\"/>\n<stop tag=\"4315\" title=\"Castro St &amp; 18th St\" lat=\"37.7607499\"
+        lon=\"-122.43507\" stopId=\"14315\"/>\n<stop tag=\"4316\" title=\"Castro St
+        &amp; 19th St\" lat=\"37.75939\" lon=\"-122.43491\" stopId=\"14316\"/>\n<stop
+        tag=\"4318\" title=\"Castro St &amp; 20th St\" lat=\"37.75778\" lon=\"-122.43477\"
+        stopId=\"14318\"/>\n<stop tag=\"4321\" title=\"Castro St &amp; 21st St\" lat=\"37.7560999\"
+        lon=\"-122.4346199\" stopId=\"14321\"/>\n<stop tag=\"4322\" title=\"Castro
+        St &amp; 22nd St\" lat=\"37.75464\" lon=\"-122.43448\" stopId=\"14322\"/>\n<stop
+        tag=\"4325\" title=\"Castro St &amp; 23rd St\" lat=\"37.7528999\" lon=\"-122.4343199\"
+        stopId=\"14325\"/>\n<stop tag=\"4333\" title=\"Castro St &amp; Elizabeth St\"
+        lat=\"37.7520799\" lon=\"-122.4342499\" stopId=\"14333\"/>\n<stop tag=\"4327\"
+        title=\"Castro St &amp; 24th St\" lat=\"37.7512499\" lon=\"-122.43418\" stopId=\"14327\"/>\n<stop
+        tag=\"4328\" title=\"Castro St &amp; 25th St\" lat=\"37.74981\" lon=\"-122.43404\"
+        stopId=\"14328\"/>\n<stop tag=\"7290\" title=\"Castro St &amp; 26th St\" lat=\"37.7481999\"
+        lon=\"-122.4338899\" stopId=\"17290\"/>\n<stop tag=\"3521\" title=\"26th St
+        &amp; Noe St\" lat=\"37.74817\" lon=\"-122.4316399\" stopId=\"13521\"/>\n<stop
+        tag=\"5732\" title=\"Noe St &amp; 27th St\" lat=\"37.7466799\" lon=\"-122.4314799\"
+        stopId=\"15732\"/>\n<stop tag=\"5734\" title=\"Noe St &amp; 28th St\" lat=\"37.74519\"
+        lon=\"-122.43134\" stopId=\"15734\"/>\n<stop tag=\"5736\" title=\"Noe St &amp;
+        29th St\" lat=\"37.74354\" lon=\"-122.43117\" stopId=\"15736\"/>\n<stop tag=\"5738\"
+        title=\"Noe St &amp; 30th St\" lat=\"37.74201\" lon=\"-122.43101\" stopId=\"15738\"/>\n<stop
+        tag=\"3544\" title=\"30th St &amp; Sanchez St\" lat=\"37.7419099\" lon=\"-122.42902\"
+        stopId=\"13544\"/>\n<stop tag=\"3536\" title=\"30th St &amp; Church St\" lat=\"37.7420399\"
+        lon=\"-122.42676\" stopId=\"13536\"/>\n<stop tag=\"3538\" title=\"30th St
+        &amp; Dolores St\" lat=\"37.7421699\" lon=\"-122.42446\" stopId=\"13538\"/>\n<stop
+        tag=\"34148\" title=\"Cortland Ave &amp; Bayshore Blvd\" lat=\"37.7395399\"
+        lon=\"-122.4072\" stopId=\"134148\"/>\n<stop tag=\"4314\" title=\"Castro St
+        &amp; 18th St\" lat=\"37.7608399\" lon=\"-122.43493\" stopId=\"14314\"/>\n<stop
+        tag=\"4313\" title=\"Castro St &amp; 17th St\" lat=\"37.76237\" lon=\"-122.43508\"
+        stopId=\"14313\"/>\n<stop tag=\"4311\" title=\"Castro St &amp; 16th St\" lat=\"37.76416\"
+        lon=\"-122.43525\" stopId=\"14311\"/>\n<stop tag=\"4310\" title=\"Castro St
+        &amp; 15th St\" lat=\"37.7656099\" lon=\"-122.4353799\" stopId=\"14310\"/>\n<stop
+        tag=\"4307\" title=\"Castro St &amp; 14th St\" lat=\"37.76761\" lon=\"-122.43558\"
+        stopId=\"14307\"/>\n<stop tag=\"4331\" title=\"Castro St &amp; Duboce Ave\"
+        lat=\"37.76895\" lon=\"-122.43571\" stopId=\"14331\"/>\n<stop tag=\"4423\"
+        title=\"Divisadero St &amp; Haight St\" lat=\"37.7713299\" lon=\"-122.43698\"
+        stopId=\"14423\"/>\n<stop tag=\"4431\" title=\"Divisadero St &amp; Oak St\"
+        lat=\"37.77319\" lon=\"-122.43735\" stopId=\"14431\"/>\n<stop tag=\"4425\"
+        title=\"Divisadero St &amp; Hayes St\" lat=\"37.77506\" lon=\"-122.43774\"
+        stopId=\"14425\"/>\n<stop tag=\"4428\" title=\"Divisadero St &amp; McAllister
+        St\" lat=\"37.7778599\" lon=\"-122.4382999\" stopId=\"14428\"/>\n<stop tag=\"4414\"
+        title=\"Divisadero St &amp; Eddy St\" lat=\"37.7804999\" lon=\"-122.43881\"
+        stopId=\"14414\"/>\n<stop tag=\"4421\" title=\"Divisadero St &amp; Geary Blvd\"
+        lat=\"37.78338\" lon=\"-122.43941\" stopId=\"14421\"/>\n<stop tag=\"4434\"
+        title=\"Divisadero St &amp; Sutter St\" lat=\"37.7853399\" lon=\"-122.43981\"
+        stopId=\"14434\"/>\n<stop tag=\"4408\" title=\"Divisadero St &amp; Bush St\"
+        lat=\"37.78628\" lon=\"-122.44\" stopId=\"14408\"/>\n<stop tag=\"4409\" title=\"Divisadero
+        St &amp; California St\" lat=\"37.7881799\" lon=\"-122.4403799\" stopId=\"14409\"/>\n<stop
+        tag=\"4412\" title=\"Divisadero St &amp; Clay St\" lat=\"37.7899799\" lon=\"-122.4407399\"
+        stopId=\"14412\"/>\n<stop tag=\"4427\" title=\"Divisadero St &amp; Jackson
+        St\" lat=\"37.79154\" lon=\"-122.44108\" stopId=\"14427\"/>\n<stop tag=\"5161\"
+        title=\"Jackson St &amp; Scott St\" lat=\"37.7917699\" lon=\"-122.43961\"
+        stopId=\"15161\"/>\n<stop tag=\"5163\" title=\"Jackson St &amp; Steiner St\"
+        lat=\"37.7921999\" lon=\"-122.43632\" stopId=\"15163\"/>\n<stop tag=\"4624\"
+        title=\"Fillmore St &amp; Jackson St\" lat=\"37.7923899\" lon=\"-122.4346099\"
+        stopId=\"14624\"/>\n<stop tag=\"6931\" title=\"Washington St &amp; Webster
+        St\" lat=\"37.7917199\" lon=\"-122.43284\" stopId=\"16931\"/>\n<stop tag=\"35167\"
+        title=\"Jackson St &amp; Webster St\" lat=\"37.7927199\" lon=\"-122.43302\"
+        stopId=\"135167\"/>\n<stop tag=\"3141\" title=\"3rd St &amp; Palou Ave\" lat=\"37.7340899\"
+        lon=\"-122.39093\" stopId=\"13141\"/>\n<stop tag=\"5490\" title=\"Newcomb
+        Ave &amp; Newhall St\" lat=\"37.7362999\" lon=\"-122.3915199\" stopId=\"15490\"/>\n<stop
+        tag=\"5491\" title=\"Newhall St &amp; Oakdale Ave\" lat=\"37.7357999\" lon=\"-122.39217\"
+        stopId=\"15491\"/>\n<stop tag=\"5492\" title=\"Newhall St &amp; Palou Ave\"
+        lat=\"37.73517\" lon=\"-122.3927399\" stopId=\"15492\"/>\n<stop tag=\"5879\"
+        title=\"Palou Ave &amp; Phelps St\" lat=\"37.7360999\" lon=\"-122.3945299\"
+        stopId=\"15879\"/>\n<stop tag=\"5881\" title=\"Palou Ave &amp; Quint St\"
+        lat=\"37.7371599\" lon=\"-122.3963699\" stopId=\"15881\"/>\n<stop tag=\"5883\"
+        title=\"Palou Ave &amp; Rankin St\" lat=\"37.73821\" lon=\"-122.39824\" stopId=\"15883\"/>\n<stop
+        tag=\"5867\" title=\"Palou Ave &amp; Industrial St\" lat=\"37.7395299\" lon=\"-122.4005499\"
+        stopId=\"15867\"/>\n<stop tag=\"5096\" title=\"Industrial St &amp; Revere
+        Ave\" lat=\"37.73913\" lon=\"-122.4030499\" stopId=\"15096\"/>\n<stop tag=\"5092\"
+        title=\"Industrial St &amp; Bayshore Blvd\" lat=\"37.7381499\" lon=\"-122.40654\"
+        stopId=\"15092\"/>\n<stop tag=\"4155\" title=\"Cortland Ave &amp; Hilton St\"
+        lat=\"37.7396899\" lon=\"-122.40781\" stopId=\"14155\"/>\n<stop tag=\"4147\"
+        title=\"Cortland Ave &amp; Bradford St\" lat=\"37.7397899\" lon=\"-122.4097499\"
+        stopId=\"14147\"/>\n<stop tag=\"4158\" title=\"Cortland Ave &amp; Prentiss
+        St\" lat=\"37.7397799\" lon=\"-122.41199\" stopId=\"14158\"/>\n<stop tag=\"4153\"
+        title=\"Cortland Ave &amp; Folsom St\" lat=\"37.739\" lon=\"-122.4136599\"
+        stopId=\"14153\"/>\n<stop tag=\"4151\" title=\"Cortland Ave &amp; Ellsworth
+        St\" lat=\"37.7389199\" lon=\"-122.41455\" stopId=\"14151\"/>\n<stop tag=\"4142\"
+        title=\"Cortland Ave &amp; Andover St\" lat=\"37.7390899\" lon=\"-122.4163899\"
+        stopId=\"14142\"/>\n<stop tag=\"4145\" title=\"Cortland Ave &amp; Bocana St\"
+        lat=\"37.7393\" lon=\"-122.41846\" stopId=\"14145\"/>\n<stop tag=\"4149\"
+        title=\"Cortland Ave &amp; Elsie St\" lat=\"37.73992\" lon=\"-122.41997\"
+        stopId=\"14149\"/>\n<stop tag=\"4160\" title=\"Cortland Ave &amp; Prospect
+        Ave\" lat=\"37.74029\" lon=\"-122.4209\" stopId=\"14160\"/>\n<stop tag=\"4156\"
+        title=\"Cortland Ave &amp; Mission St\" lat=\"37.7410099\" lon=\"-122.4226699\"
+        stopId=\"14156\"/>\n<stop tag=\"3540\" title=\"30th St &amp; Mission St\"
+        lat=\"37.7424399\" lon=\"-122.42206\" stopId=\"13540\"/>\n<stop tag=\"3537\"
+        title=\"30th St &amp; Dolores St\" lat=\"37.7423\" lon=\"-122.4240299\" stopId=\"13537\"/>\n<stop
+        tag=\"3535\" title=\"30th St &amp; Church St\" lat=\"37.74216\" lon=\"-122.4263699\"
+        stopId=\"13535\"/>\n<stop tag=\"3543\" title=\"30th St &amp; Sanchez St\"
+        lat=\"37.7420199\" lon=\"-122.4286\" stopId=\"13543\"/>\n<stop tag=\"3542\"
+        title=\"30th St &amp; Noe St\" lat=\"37.7418799\" lon=\"-122.43079\" stopId=\"13542\"/>\n<stop
+        tag=\"5737\" title=\"Noe St &amp; 29th St\" lat=\"37.7433\" lon=\"-122.43104\"
+        stopId=\"15737\"/>\n<stop tag=\"5735\" title=\"Noe St &amp; 28th St\" lat=\"37.7449299\"
+        lon=\"-122.4311699\" stopId=\"15735\"/>\n<stop tag=\"5733\" title=\"Noe St
+        &amp; 27th St\" lat=\"37.7465399\" lon=\"-122.4313199\" stopId=\"15733\"/>\n<stop
+        tag=\"3520\" title=\"26th St &amp; Noe St\" lat=\"37.7482699\" lon=\"-122.43177\"
+        stopId=\"13520\"/>\n<stop tag=\"3514\" title=\"26th St &amp; Castro St\" lat=\"37.74815\"
+        lon=\"-122.4336299\" stopId=\"13514\"/>\n<stop tag=\"4329\" title=\"Castro
+        St &amp; 25th St\" lat=\"37.7495999\" lon=\"-122.4338299\" stopId=\"14329\"/>\n<stop
+        tag=\"4326\" title=\"Castro St &amp; 24th St\" lat=\"37.7511999\" lon=\"-122.43401\"
+        stopId=\"14326\"/>\n<stop tag=\"4332\" title=\"Castro St &amp; Elizabeth St\"
+        lat=\"37.75189\" lon=\"-122.43405\" stopId=\"14332\"/>\n<stop tag=\"4324\"
+        title=\"Castro St &amp; 23rd St\" lat=\"37.75278\" lon=\"-122.43416\" stopId=\"14324\"/>\n<stop
+        tag=\"4323\" title=\"Castro St &amp; 22nd St\" lat=\"37.75441\" lon=\"-122.43431\"
+        stopId=\"14323\"/>\n<stop tag=\"4320\" title=\"Castro St &amp; 21st St\" lat=\"37.7559599\"
+        lon=\"-122.4344599\" stopId=\"14320\"/>\n<stop tag=\"4319\" title=\"Castro
+        St &amp; 20th St\" lat=\"37.7576299\" lon=\"-122.4346399\" stopId=\"14319\"/>\n<stop
+        tag=\"4317\" title=\"Castro St &amp; 19th St\" lat=\"37.7591599\" lon=\"-122.4347899\"
+        stopId=\"14317\"/>\n<stop tag=\"34435\" title=\"Divisadero St &amp; Sutter
+        St\" lat=\"37.7851499\" lon=\"-122.43994\" stopId=\"134435\"/>\n<stop tag=\"14148\"
+        title=\"Cortland Ave &amp; Bayshore Blvd\" lat=\"37.7395399\" lon=\"-122.4072\"
+        stopId=\"114148\"/>\n<direction tag=\"24_OB3\" title=\"Outbound to the Bayview
+        District\" name=\"Outbound\" useForUI=\"true\">\n  <stop tag=\"5167\" />\n
+        \ <stop tag=\"5147\" />\n  <stop tag=\"5162\" />\n  <stop tag=\"5160\" />\n
+        \ <stop tag=\"5145\" />\n  <stop tag=\"4413\" />\n  <stop tag=\"4410\" />\n
+        \ <stop tag=\"4433\" />\n  <stop tag=\"4435\" />\n  <stop tag=\"4422\" />\n
+        \ <stop tag=\"4415\" />\n  <stop tag=\"4429\" />\n  <stop tag=\"4426\" />\n
+        \ <stop tag=\"4432\" />\n  <stop tag=\"4424\" />\n  <stop tag=\"4330\" />\n
+        \ <stop tag=\"4308\" />\n  <stop tag=\"4309\" />\n  <stop tag=\"4312\" />\n
+        \ <stop tag=\"4334\" />\n  <stop tag=\"4315\" />\n  <stop tag=\"4316\" />\n
+        \ <stop tag=\"4318\" />\n  <stop tag=\"4321\" />\n  <stop tag=\"4322\" />\n
+        \ <stop tag=\"4325\" />\n  <stop tag=\"4333\" />\n  <stop tag=\"4327\" />\n
+        \ <stop tag=\"4328\" />\n  <stop tag=\"7290\" />\n  <stop tag=\"3521\" />\n
+        \ <stop tag=\"5732\" />\n  <stop tag=\"5734\" />\n  <stop tag=\"5736\" />\n
+        \ <stop tag=\"5738\" />\n  <stop tag=\"3544\" />\n  <stop tag=\"3536\" />\n
+        \ <stop tag=\"3538\" />\n  <stop tag=\"3541\" />\n  <stop tag=\"4157\" />\n
+        \ <stop tag=\"4161\" />\n  <stop tag=\"4150\" />\n  <stop tag=\"4146\" />\n
+        \ <stop tag=\"4143\" />\n  <stop tag=\"4152\" />\n  <stop tag=\"4154\" />\n
+        \ <stop tag=\"4159\" />\n  <stop tag=\"7213\" />\n  <stop tag=\"4148\" />\n
+        \ <stop tag=\"5093\" />\n  <stop tag=\"5094\" />\n  <stop tag=\"5095\" />\n
+        \ <stop tag=\"5884\" />\n  <stop tag=\"5882\" />\n  <stop tag=\"5880\" />\n
+        \ <stop tag=\"5878\" />\n  <stop tag=\"33141\" />\n</direction>\n<direction
+        tag=\"24_IB1\" title=\"Inbound to Pacific Heights\" name=\"Inbound\" useForUI=\"true\">\n
+        \ <stop tag=\"3141\" />\n  <stop tag=\"5490\" />\n  <stop tag=\"5491\" />\n
+        \ <stop tag=\"5492\" />\n  <stop tag=\"5879\" />\n  <stop tag=\"5881\" />\n
+        \ <stop tag=\"5883\" />\n  <stop tag=\"5867\" />\n  <stop tag=\"5096\" />\n
+        \ <stop tag=\"5092\" />\n  <stop tag=\"4155\" />\n  <stop tag=\"4147\" />\n
+        \ <stop tag=\"4158\" />\n  <stop tag=\"4153\" />\n  <stop tag=\"4151\" />\n
+        \ <stop tag=\"4142\" />\n  <stop tag=\"4145\" />\n  <stop tag=\"4149\" />\n
+        \ <stop tag=\"4160\" />\n  <stop tag=\"4156\" />\n  <stop tag=\"3540\" />\n
+        \ <stop tag=\"3537\" />\n  <stop tag=\"3535\" />\n  <stop tag=\"3543\" />\n
+        \ <stop tag=\"3542\" />\n  <stop tag=\"5737\" />\n  <stop tag=\"5735\" />\n
+        \ <stop tag=\"5733\" />\n  <stop tag=\"3520\" />\n  <stop tag=\"3514\" />\n
+        \ <stop tag=\"4329\" />\n  <stop tag=\"4326\" />\n  <stop tag=\"4332\" />\n
+        \ <stop tag=\"4324\" />\n  <stop tag=\"4323\" />\n  <stop tag=\"4320\" />\n
+        \ <stop tag=\"4319\" />\n  <stop tag=\"4317\" />\n  <stop tag=\"4314\" />\n
+        \ <stop tag=\"4313\" />\n  <stop tag=\"4311\" />\n  <stop tag=\"4310\" />\n
+        \ <stop tag=\"4307\" />\n  <stop tag=\"4331\" />\n  <stop tag=\"4423\" />\n
+        \ <stop tag=\"4431\" />\n  <stop tag=\"4425\" />\n  <stop tag=\"4428\" />\n
+        \ <stop tag=\"4414\" />\n  <stop tag=\"4421\" />\n  <stop tag=\"4434\" />\n
+        \ <stop tag=\"4408\" />\n  <stop tag=\"4409\" />\n  <stop tag=\"4412\" />\n
+        \ <stop tag=\"4427\" />\n  <stop tag=\"5161\" />\n  <stop tag=\"5163\" />\n
+        \ <stop tag=\"4624\" />\n  <stop tag=\"6931\" />\n  <stop tag=\"35167\" />\n</direction>\n<path>\n<point
+        lat=\"37.7805\" lon=\"-122.43881\"/>\n<point lat=\"37.78515\" lon=\"-122.43994\"/>\n</path>\n<path>\n<point
+        lat=\"37.77105\" lon=\"-122.4371\"/>\n<point lat=\"37.77034\" lon=\"-122.43686\"/>\n<point
+        lat=\"37.76996\" lon=\"-122.43632\"/>\n<point lat=\"37.76975\" lon=\"-122.4362\"/>\n<point
+        lat=\"37.76938\" lon=\"-122.43592\"/>\n<point lat=\"37.76918\" lon=\"-122.43596\"/>\n<point
+        lat=\"37.76906\" lon=\"-122.4358\"/>\n<point lat=\"37.76742\" lon=\"-122.43571\"/>\n<point
+        lat=\"37.76583\" lon=\"-122.43557\"/>\n<point lat=\"37.76427\" lon=\"-122.43544\"/>\n<point
+        lat=\"37.76214\" lon=\"-122.43519\"/>\n<point lat=\"37.76075\" lon=\"-122.43507\"/>\n</path>\n<path>\n<point
+        lat=\"37.74231\" lon=\"-122.42217\"/>\n<point lat=\"37.74103\" lon=\"-122.42285\"/>\n<point
+        lat=\"37.74085\" lon=\"-122.42251\"/>\n<point lat=\"37.7402\" lon=\"-122.42093\"/>\n<point
+        lat=\"37.7397\" lon=\"-122.41969\"/>\n<point lat=\"37.73931\" lon=\"-122.41872\"/>\n<point
+        lat=\"37.7393\" lon=\"-122.41859\"/>\n<point lat=\"37.73904\" lon=\"-122.41658\"/>\n<point
+        lat=\"37.73888\" lon=\"-122.41467\"/>\n<point lat=\"37.73883\" lon=\"-122.41461\"/>\n<point
+        lat=\"37.73892\" lon=\"-122.41343\"/>\n<point lat=\"37.73897\" lon=\"-122.41341\"/>\n<point
+        lat=\"37.73931\" lon=\"-122.41267\"/>\n<point lat=\"37.73957\" lon=\"-122.41211\"/>\n<point
+        lat=\"37.7398499\" lon=\"-122.41175\"/>\n<point lat=\"37.73971\" lon=\"-122.41017\"/>\n<point
+        lat=\"37.73954\" lon=\"-122.4072\"/>\n</path>\n<path>\n<point lat=\"37.73954\"
+        lon=\"-122.4072\"/>\n<point lat=\"37.73907\" lon=\"-122.40712\"/>\n<point
+        lat=\"37.7388199\" lon=\"-122.40726\"/>\n<point lat=\"37.73888\" lon=\"-122.40755\"/>\n<point
+        lat=\"37.73934\" lon=\"-122.40766\"/>\n<point lat=\"37.73961\" lon=\"-122.40765\"/>\n<point
+        lat=\"37.73969\" lon=\"-122.40781\"/>\n</path>\n<path>\n<point lat=\"37.7805\"
+        lon=\"-122.43881\"/>\n<point lat=\"37.78338\" lon=\"-122.43941\"/>\n<point
+        lat=\"37.78534\" lon=\"-122.43981\"/>\n</path>\n<path>\n<point lat=\"37.73969\"
+        lon=\"-122.40781\"/>\n<point lat=\"37.73979\" lon=\"-122.40975\"/>\n<point
+        lat=\"37.7398499\" lon=\"-122.41175\"/>\n<point lat=\"37.73978\" lon=\"-122.41199\"/>\n<point
+        lat=\"37.739\" lon=\"-122.41319\"/>\n<point lat=\"37.739\" lon=\"-122.41366\"/>\n<point
+        lat=\"37.73892\" lon=\"-122.41455\"/>\n<point lat=\"37.73888\" lon=\"-122.41457\"/>\n<point
+        lat=\"37.73909\" lon=\"-122.41639\"/>\n<point lat=\"37.73925\" lon=\"-122.41846\"/>\n<point
+        lat=\"37.7393\" lon=\"-122.41846\"/>\n<point lat=\"37.73992\" lon=\"-122.41997\"/>\n<point
+        lat=\"37.74029\" lon=\"-122.4209\"/>\n<point lat=\"37.74101\" lon=\"-122.42267\"/>\n<point
+        lat=\"37.74103\" lon=\"-122.42285\"/>\n<point lat=\"37.74244\" lon=\"-122.42206\"/>\n</path>\n<path>\n<point
+        lat=\"37.74244\" lon=\"-122.42206\"/>\n<point lat=\"37.7423\" lon=\"-122.42329\"/>\n<point
+        lat=\"37.7423\" lon=\"-122.42403\"/>\n<point lat=\"37.74216\" lon=\"-122.42637\"/>\n<point
+        lat=\"37.7420199\" lon=\"-122.4286\"/>\n<point lat=\"37.74188\" lon=\"-122.43079\"/>\n<point
+        lat=\"37.74184\" lon=\"-122.43089\"/>\n<point lat=\"37.7433\" lon=\"-122.43104\"/>\n<point
+        lat=\"37.7449299\" lon=\"-122.43117\"/>\n<point lat=\"37.74654\" lon=\"-122.43132\"/>\n<point
+        lat=\"37.74814\" lon=\"-122.43154\"/>\n<point lat=\"37.74827\" lon=\"-122.43177\"/>\n<point
+        lat=\"37.74815\" lon=\"-122.43363\"/>\n<point lat=\"37.7481\" lon=\"-122.43378\"/>\n<point
+        lat=\"37.7496\" lon=\"-122.43383\"/>\n<point lat=\"37.7512\" lon=\"-122.43401\"/>\n</path>\n<path>\n<point
+        lat=\"37.76075\" lon=\"-122.43507\"/>\n<point lat=\"37.75939\" lon=\"-122.43491\"/>\n<point
+        lat=\"37.7577799\" lon=\"-122.43477\"/>\n<point lat=\"37.7561\" lon=\"-122.43462\"/>\n<point
+        lat=\"37.75464\" lon=\"-122.43448\"/>\n<point lat=\"37.7528999\" lon=\"-122.43432\"/>\n<point
+        lat=\"37.75208\" lon=\"-122.43425\"/>\n<point lat=\"37.75125\" lon=\"-122.43418\"/>\n</path>\n<path>\n<point
+        lat=\"37.73409\" lon=\"-122.39093\"/>\n<point lat=\"37.73559\" lon=\"-122.39042\"/>\n<point
+        lat=\"37.7363\" lon=\"-122.39152\"/>\n<point lat=\"37.7363\" lon=\"-122.39165\"/>\n<point
+        lat=\"37.7358\" lon=\"-122.39217\"/>\n<point lat=\"37.7351699\" lon=\"-122.39274\"/>\n<point
+        lat=\"37.73504\" lon=\"-122.39278\"/>\n<point lat=\"37.7361\" lon=\"-122.39453\"/>\n<point
+        lat=\"37.73716\" lon=\"-122.39637\"/>\n<point lat=\"37.73821\" lon=\"-122.39824\"/>\n<point
+        lat=\"37.73953\" lon=\"-122.40055\"/>\n<point lat=\"37.73966\" lon=\"-122.4009\"/>\n<point
+        lat=\"37.73913\" lon=\"-122.40305\"/>\n<point lat=\"37.73815\" lon=\"-122.40654\"/>\n<point
+        lat=\"37.73797\" lon=\"-122.40692\"/>\n<point lat=\"37.73846\" lon=\"-122.40707\"/>\n<point
+        lat=\"37.73907\" lon=\"-122.40712\"/>\n<point lat=\"37.73932\" lon=\"-122.40708\"/>\n<point
+        lat=\"37.73957\" lon=\"-122.40698\"/>\n<point lat=\"37.73969\" lon=\"-122.40781\"/>\n</path>\n<path>\n<point
+        lat=\"37.77133\" lon=\"-122.43698\"/>\n<point lat=\"37.77319\" lon=\"-122.43735\"/>\n<point
+        lat=\"37.77506\" lon=\"-122.43774\"/>\n<point lat=\"37.7778599\" lon=\"-122.4383\"/>\n<point
+        lat=\"37.7805\" lon=\"-122.43881\"/>\n</path>\n<path>\n<point lat=\"37.78534\"
+        lon=\"-122.43981\"/>\n<point lat=\"37.78628\" lon=\"-122.44\"/>\n<point lat=\"37.7881799\"
+        lon=\"-122.44038\"/>\n<point lat=\"37.78998\" lon=\"-122.44074\"/>\n<point
+        lat=\"37.79154\" lon=\"-122.44108\"/>\n<point lat=\"37.79163\" lon=\"-122.44116\"/>\n<point
+        lat=\"37.79177\" lon=\"-122.43961\"/>\n<point lat=\"37.7922\" lon=\"-122.43632\"/>\n<point
+        lat=\"37.79247\" lon=\"-122.43456\"/>\n<point lat=\"37.79239\" lon=\"-122.43461\"/>\n<point
+        lat=\"37.79158\" lon=\"-122.43439\"/>\n<point lat=\"37.79172\" lon=\"-122.43284\"/>\n<point
+        lat=\"37.7918\" lon=\"-122.43275\"/>\n<point lat=\"37.79267\" lon=\"-122.43292\"/>\n<point
+        lat=\"37.79272\" lon=\"-122.43302\"/>\n</path>\n<path>\n<point lat=\"37.76084\"
+        lon=\"-122.43493\"/>\n<point lat=\"37.76237\" lon=\"-122.43508\"/>\n<point
+        lat=\"37.7641599\" lon=\"-122.43525\"/>\n<point lat=\"37.76561\" lon=\"-122.43538\"/>\n<point
+        lat=\"37.76761\" lon=\"-122.43558\"/>\n<point lat=\"37.7689499\" lon=\"-122.43571\"/>\n<point
+        lat=\"37.76906\" lon=\"-122.4358\"/>\n<point lat=\"37.76938\" lon=\"-122.43592\"/>\n<point
+        lat=\"37.76975\" lon=\"-122.4362\"/>\n<point lat=\"37.76996\" lon=\"-122.43632\"/>\n<point
+        lat=\"37.77029\" lon=\"-122.43678\"/>\n<point lat=\"37.77133\" lon=\"-122.43698\"/>\n</path>\n<path>\n<point
+        lat=\"37.73954\" lon=\"-122.4072\"/>\n<point lat=\"37.73957\" lon=\"-122.40698\"/>\n<point
+        lat=\"37.73932\" lon=\"-122.40708\"/>\n<point lat=\"37.73907\" lon=\"-122.40712\"/>\n<point
+        lat=\"37.7381\" lon=\"-122.40701\"/>\n<point lat=\"37.73794\" lon=\"-122.40678\"/>\n<point
+        lat=\"37.73833\" lon=\"-122.40566\"/>\n<point lat=\"37.73879\" lon=\"-122.40373\"/>\n<point
+        lat=\"37.73955\" lon=\"-122.40101\"/>\n<point lat=\"37.73966\" lon=\"-122.4009\"/>\n<point
+        lat=\"37.73825\" lon=\"-122.39853\"/>\n<point lat=\"37.73722\" lon=\"-122.39672\"/>\n<point
+        lat=\"37.7361\" lon=\"-122.39481\"/>\n<point lat=\"37.73503\" lon=\"-122.39266\"/>\n<point
+        lat=\"37.73409\" lon=\"-122.39093\"/>\n</path>\n<path>\n<point lat=\"37.78045\"
+        lon=\"-122.43898\"/>\n<point lat=\"37.7776799\" lon=\"-122.43841\"/>\n<point
+        lat=\"37.77489\" lon=\"-122.43786\"/>\n<point lat=\"37.77305\" lon=\"-122.43749\"/>\n<point
+        lat=\"37.77105\" lon=\"-122.4371\"/>\n</path>\n<path>\n<point lat=\"37.78515\"
+        lon=\"-122.43994\"/>\n<point lat=\"37.78316\" lon=\"-122.43953\"/>\n<point
+        lat=\"37.78045\" lon=\"-122.43898\"/>\n</path>\n<path>\n<point lat=\"37.75125\"
+        lon=\"-122.43418\"/>\n<point lat=\"37.7498099\" lon=\"-122.43404\"/>\n<point
+        lat=\"37.7482\" lon=\"-122.43389\"/>\n<point lat=\"37.7481\" lon=\"-122.43378\"/>\n<point
+        lat=\"37.74817\" lon=\"-122.43164\"/>\n<point lat=\"37.74823\" lon=\"-122.43157\"/>\n<point
+        lat=\"37.74668\" lon=\"-122.43148\"/>\n<point lat=\"37.74519\" lon=\"-122.43134\"/>\n<point
+        lat=\"37.74354\" lon=\"-122.43117\"/>\n<point lat=\"37.74201\" lon=\"-122.43101\"/>\n<point
+        lat=\"37.74192\" lon=\"-122.43096\"/>\n<point lat=\"37.74189\" lon=\"-122.42995\"/>\n<point
+        lat=\"37.74191\" lon=\"-122.42902\"/>\n<point lat=\"37.74204\" lon=\"-122.42676\"/>\n<point
+        lat=\"37.74217\" lon=\"-122.42446\"/>\n<point lat=\"37.74231\" lon=\"-122.42217\"/>\n</path>\n<path>\n<point
+        lat=\"37.73969\" lon=\"-122.40781\"/>\n<point lat=\"37.73979\" lon=\"-122.40975\"/>\n<point
+        lat=\"37.7398499\" lon=\"-122.41175\"/>\n<point lat=\"37.73978\" lon=\"-122.41199\"/>\n<point
+        lat=\"37.739\" lon=\"-122.41319\"/>\n<point lat=\"37.739\" lon=\"-122.41366\"/>\n<point
+        lat=\"37.73892\" lon=\"-122.41455\"/>\n<point lat=\"37.73888\" lon=\"-122.41457\"/>\n<point
+        lat=\"37.73909\" lon=\"-122.41639\"/>\n<point lat=\"37.73925\" lon=\"-122.41846\"/>\n<point
+        lat=\"37.7393\" lon=\"-122.41846\"/>\n<point lat=\"37.73992\" lon=\"-122.41997\"/>\n<point
+        lat=\"37.74029\" lon=\"-122.4209\"/>\n<point lat=\"37.74101\" lon=\"-122.42267\"/>\n<point
+        lat=\"37.74103\" lon=\"-122.42285\"/>\n<point lat=\"37.7421999\" lon=\"-122.42209\"/>\n<point
+        lat=\"37.74244\" lon=\"-122.42206\"/>\n</path>\n<path>\n<point lat=\"37.7512\"
+        lon=\"-122.43401\"/>\n<point lat=\"37.75189\" lon=\"-122.43405\"/>\n<point
+        lat=\"37.75278\" lon=\"-122.43416\"/>\n<point lat=\"37.75441\" lon=\"-122.43431\"/>\n<point
+        lat=\"37.75596\" lon=\"-122.43446\"/>\n<point lat=\"37.75763\" lon=\"-122.43464\"/>\n<point
+        lat=\"37.75916\" lon=\"-122.43479\"/>\n<point lat=\"37.76084\" lon=\"-122.43493\"/>\n</path>\n<path>\n<point
+        lat=\"37.73409\" lon=\"-122.39093\"/>\n<point lat=\"37.73559\" lon=\"-122.39042\"/>\n<point
+        lat=\"37.7363\" lon=\"-122.39152\"/>\n<point lat=\"37.7363\" lon=\"-122.39165\"/>\n<point
+        lat=\"37.7358\" lon=\"-122.39217\"/>\n<point lat=\"37.7351699\" lon=\"-122.39274\"/>\n<point
+        lat=\"37.73504\" lon=\"-122.39278\"/>\n<point lat=\"37.73566\" lon=\"-122.39222\"/>\n<point
+        lat=\"37.73504\" lon=\"-122.39278\"/>\n<point lat=\"37.7361\" lon=\"-122.39453\"/>\n<point
+        lat=\"37.73716\" lon=\"-122.39637\"/>\n<point lat=\"37.73821\" lon=\"-122.39824\"/>\n<point
+        lat=\"37.73953\" lon=\"-122.40055\"/>\n<point lat=\"37.73966\" lon=\"-122.4009\"/>\n<point
+        lat=\"37.73913\" lon=\"-122.40305\"/>\n<point lat=\"37.73815\" lon=\"-122.40654\"/>\n<point
+        lat=\"37.73797\" lon=\"-122.40692\"/>\n<point lat=\"37.73846\" lon=\"-122.40707\"/>\n<point
+        lat=\"37.73907\" lon=\"-122.40712\"/>\n<point lat=\"37.73932\" lon=\"-122.40708\"/>\n<point
+        lat=\"37.73957\" lon=\"-122.40698\"/>\n<point lat=\"37.73969\" lon=\"-122.40781\"/>\n</path>\n<path>\n<point
+        lat=\"37.7805\" lon=\"-122.43881\"/>\n<point lat=\"37.78534\" lon=\"-122.43981\"/>\n</path>\n<path>\n<point
+        lat=\"37.74231\" lon=\"-122.42217\"/>\n<point lat=\"37.74238\" lon=\"-122.42198\"/>\n<point
+        lat=\"37.74103\" lon=\"-122.42285\"/>\n<point lat=\"37.74085\" lon=\"-122.42251\"/>\n<point
+        lat=\"37.7402\" lon=\"-122.42093\"/>\n<point lat=\"37.7397\" lon=\"-122.41969\"/>\n<point
+        lat=\"37.73931\" lon=\"-122.41872\"/>\n<point lat=\"37.7393\" lon=\"-122.41859\"/>\n<point
+        lat=\"37.73904\" lon=\"-122.41658\"/>\n<point lat=\"37.73888\" lon=\"-122.41467\"/>\n<point
+        lat=\"37.73883\" lon=\"-122.41461\"/>\n<point lat=\"37.73892\" lon=\"-122.41343\"/>\n<point
+        lat=\"37.73897\" lon=\"-122.41341\"/>\n<point lat=\"37.73931\" lon=\"-122.41267\"/>\n<point
+        lat=\"37.73957\" lon=\"-122.41211\"/>\n<point lat=\"37.7398499\" lon=\"-122.41175\"/>\n<point
+        lat=\"37.73971\" lon=\"-122.41017\"/>\n<point lat=\"37.73954\" lon=\"-122.4072\"/>\n</path>\n<path>\n<point
+        lat=\"37.79272\" lon=\"-122.43302\"/>\n<point lat=\"37.79253\" lon=\"-122.43468\"/>\n<point
+        lat=\"37.79235\" lon=\"-122.43611\"/>\n<point lat=\"37.79193\" lon=\"-122.43924\"/>\n<point
+        lat=\"37.79172\" lon=\"-122.44089\"/>\n<point lat=\"37.79163\" lon=\"-122.44116\"/>\n<point
+        lat=\"37.7899699\" lon=\"-122.44089\"/>\n<point lat=\"37.78799\" lon=\"-122.4405\"/>\n<point
+        lat=\"37.787\" lon=\"-122.44032\"/>\n<point lat=\"37.78515\" lon=\"-122.43994\"/>\n</path>\n<path>\n<point
+        lat=\"37.78534\" lon=\"-122.43981\"/>\n<point lat=\"37.78628\" lon=\"-122.44\"/>\n<point
+        lat=\"37.7881799\" lon=\"-122.44038\"/>\n<point lat=\"37.78998\" lon=\"-122.44074\"/>\n<point
+        lat=\"37.79154\" lon=\"-122.44108\"/>\n<point lat=\"37.79163\" lon=\"-122.44116\"/>\n<point
+        lat=\"37.79177\" lon=\"-122.43961\"/>\n<point lat=\"37.7922\" lon=\"-122.43632\"/>\n</path>\n</route>\n</body>\n"
+    http_version: 
+  recorded_at: Tue, 26 Mar 2013 19:47:56 GMT
+recorded_with: VCR 2.4.0

--- a/spec/cassettes/Muni_Direction/_stop_at/given_a_stop_title/should_return_corresponding_stop.yml
+++ b/spec/cassettes/Muni_Direction/_stop_at/given_a_stop_title/should_return_corresponding_stop.yml
@@ -1,0 +1,204 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://webservices.nextbus.com/service/publicXMLFeed?a=sf-muni&command=routeConfig&r=21
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - '*/*'
+      User-Agent:
+      - Ruby
+      Host:
+      - webservices.nextbus.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 Mar 2013 19:41:23 GMT
+      Server:
+      - Apache/2.2.4 (Unix) mod_ssl/2.2.4 OpenSSL/0.9.7m DAV/2 mod_jk/1.2.30
+      Access-Control-Allow-Origin:
+      - '*'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2235'
+      Content-Type:
+      - text/xml
+      X-Pad:
+      - avoid browser bug
+    body:
+      encoding: UTF-8
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\" ?> \n<body copyright=\"All
+        data copyright San Francisco Muni 2013.\">\n<route tag=\"21\" title=\"21-Hayes\"
+        color=\"660000\" oppositeColor=\"ffffff\" latMin=\"37.7729599\" latMax=\"37.7944299\"
+        lonMin=\"-122.46384\" lonMax=\"-122.39323\">\n<stop tag=\"6497\" title=\"Steuart
+        St &amp; Mission St\" lat=\"37.7933499\" lon=\"-122.39323\" stopId=\"16497\"/>\n<stop
+        tag=\"6501\" title=\"Steuart St &amp; Market St\" lat=\"37.7944299\" lon=\"-122.3945499\"
+        stopId=\"16501\"/>\n<stop tag=\"5669\" title=\"Market St &amp; Drumm St\"
+        lat=\"37.79347\" lon=\"-122.3961799\" stopId=\"15669\"/>\n<stop tag=\"5671\"
+        title=\"Market St &amp; Front St\" lat=\"37.79192\" lon=\"-122.3981499\" stopId=\"15671\"/>\n<stop
+        tag=\"5689\" title=\"Market St &amp; Sansome St\" lat=\"37.7901599\" lon=\"-122.40041\"
+        stopId=\"15689\"/>\n<stop tag=\"5684\" title=\"Market St &amp; Montgomery
+        St\" lat=\"37.7884899\" lon=\"-122.40248\" stopId=\"15684\"/>\n<stop tag=\"5674\"
+        title=\"Market St &amp; Grant Ave\" lat=\"37.78639\" lon=\"-122.4051599\"
+        stopId=\"15674\"/>\n<stop tag=\"5688\" title=\"Market St &amp; Powell St\"
+        lat=\"37.7846799\" lon=\"-122.40731\" stopId=\"15688\"/>\n<stop tag=\"5683\"
+        title=\"Market St &amp; Mason St\" lat=\"37.7828499\" lon=\"-122.40964\" stopId=\"15683\"/>\n<stop
+        tag=\"5656\" title=\"Market St &amp; 7th St North\" lat=\"37.7805699\" lon=\"-122.41244\"
+        stopId=\"15656\"/>\n<stop tag=\"7423\" title=\"Market St &amp; Hyde St\" lat=\"37.7787799\"
+        lon=\"-122.41472\" stopId=\"17423\"/>\n<stop tag=\"4997\" title=\"Hayes St
+        &amp; Larkin St\" lat=\"37.7777099\" lon=\"-122.41685\" stopId=\"14997\"/>\n<stop
+        tag=\"5013\" title=\"Hayes St &amp; Van Ness Ave\" lat=\"37.7772899\" lon=\"-122.42019\"
+        stopId=\"15013\"/>\n<stop tag=\"4996\" title=\"Hayes St &amp; Gough St\" lat=\"37.77689\"
+        lon=\"-122.4233299\" stopId=\"14996\"/>\n<stop tag=\"4998\" title=\"Hayes
+        St &amp; Laguna St\" lat=\"37.7765299\" lon=\"-122.42615\" stopId=\"14998\"/>\n<stop
+        tag=\"4983\" title=\"Hayes St &amp; Buchanan St\" lat=\"37.7762599\" lon=\"-122.42827\"
+        stopId=\"14983\"/>\n<stop tag=\"5014\" title=\"Hayes St &amp; Webster St\"
+        lat=\"37.7760599\" lon=\"-122.42988\" stopId=\"15014\"/>\n<stop tag=\"4993\"
+        title=\"Hayes St &amp; Fillmore St\" lat=\"37.77584\" lon=\"-122.4315599\"
+        stopId=\"14993\"/>\n<stop tag=\"5011\" title=\"Hayes St &amp; Steiner St\"
+        lat=\"37.77563\" lon=\"-122.4331999\" stopId=\"15011\"/>\n<stop tag=\"5003\"
+        title=\"Hayes St &amp; Pierce St\" lat=\"37.77547\" lon=\"-122.4344399\" stopId=\"15003\"/>\n<stop
+        tag=\"4991\" title=\"Hayes St &amp; Divisadero St\" lat=\"37.7749899\" lon=\"-122.43818\"
+        stopId=\"14991\"/>\n<stop tag=\"4979\" title=\"Hayes St &amp; Baker St\" lat=\"37.7745699\"
+        lon=\"-122.4415\" stopId=\"14979\"/>\n<stop tag=\"4999\" title=\"Hayes St
+        &amp; Lyon St\" lat=\"37.77443\" lon=\"-122.4426299\" stopId=\"14999\"/>\n<stop
+        tag=\"4985\" title=\"Hayes St &amp; Central Ave\" lat=\"37.7742\" lon=\"-122.4442999\"
+        stopId=\"14985\"/>\n<stop tag=\"5001\" title=\"Hayes St &amp; Masonic Ave\"
+        lat=\"37.7739299\" lon=\"-122.44651\" stopId=\"15001\"/>\n<stop tag=\"4987\"
+        title=\"Hayes St &amp; Clayton St\" lat=\"37.7736099\" lon=\"-122.44917\"
+        stopId=\"14987\"/>\n<stop tag=\"5007\" title=\"Hayes St &amp; Shrader St\"
+        lat=\"37.7731699\" lon=\"-122.4525\" stopId=\"15007\"/>\n<stop tag=\"5009\"
+        title=\"Hayes St &amp; Stanyan St\" lat=\"37.7729599\" lon=\"-122.45415\"
+        stopId=\"15009\"/>\n<stop tag=\"37499\" title=\"Fulton St &amp; Shrader St\"
+        lat=\"37.7748699\" lon=\"-122.45309\" stopId=\"137499\"/>\n<stop tag=\"7499\"
+        title=\"Fulton St &amp; Shrader St\" lat=\"37.7748699\" lon=\"-122.45309\"
+        stopId=\"17499\"/>\n<stop tag=\"7561\" title=\"Hayes St &amp; Shrader St\"
+        lat=\"37.77306\" lon=\"-122.4525099\" stopId=\"17561\"/>\n<stop tag=\"4988\"
+        title=\"Hayes St &amp; Clayton St\" lat=\"37.7734199\" lon=\"-122.44946\"
+        stopId=\"14988\"/>\n<stop tag=\"5002\" title=\"Hayes St &amp; Masonic Ave\"
+        lat=\"37.7739499\" lon=\"-122.44568\" stopId=\"15002\"/>\n<stop tag=\"4986\"
+        title=\"Hayes St &amp; Central Ave\" lat=\"37.77409\" lon=\"-122.4445099\"
+        stopId=\"14986\"/>\n<stop tag=\"5000\" title=\"Hayes St &amp; Lyon St\" lat=\"37.7742899\"
+        lon=\"-122.44286\" stopId=\"15000\"/>\n<stop tag=\"4980\" title=\"Hayes St
+        &amp; Baker St\" lat=\"37.7745099\" lon=\"-122.44126\" stopId=\"14980\"/>\n<stop
+        tag=\"4992\" title=\"Hayes St &amp; Divisadero St\" lat=\"37.7749999\" lon=\"-122.4374\"
+        stopId=\"14992\"/>\n<stop tag=\"5004\" title=\"Hayes St &amp; Pierce St\"
+        lat=\"37.7754099\" lon=\"-122.43418\" stopId=\"15004\"/>\n<stop tag=\"5012\"
+        title=\"Hayes St &amp; Steiner St\" lat=\"37.77563\" lon=\"-122.4324799\"
+        stopId=\"15012\"/>\n<stop tag=\"4994\" title=\"Hayes St &amp; Fillmore St\"
+        lat=\"37.7757999\" lon=\"-122.43083\" stopId=\"14994\"/>\n<stop tag=\"5015\"
+        title=\"Hayes St &amp; Webster St\" lat=\"37.7760399\" lon=\"-122.42919\"
+        stopId=\"15015\"/>\n<stop tag=\"4984\" title=\"Hayes St &amp; Buchanan St\"
+        lat=\"37.77624\" lon=\"-122.4275499\" stopId=\"14984\"/>\n<stop tag=\"5260\"
+        title=\"Laguna St &amp; Hayes St\" lat=\"37.7767499\" lon=\"-122.42627\" stopId=\"15260\"/>\n<stop
+        tag=\"4921\" title=\"Grove St &amp; Laguna St\" lat=\"37.77738\" lon=\"-122.4263199\"
+        stopId=\"14921\"/>\n<stop tag=\"4920\" title=\"Grove St &amp; Gough St\" lat=\"37.77775\"
+        lon=\"-122.4233099\" stopId=\"14920\"/>\n<stop tag=\"4923\" title=\"Grove
+        St &amp; Van Ness Ave\" lat=\"37.7781899\" lon=\"-122.41974\" stopId=\"14923\"/>\n<stop
+        tag=\"7463\" title=\"Grove St &amp; Polk St\" lat=\"37.77838\" lon=\"-122.4183099\"
+        stopId=\"17463\"/>\n<stop tag=\"5652\" title=\"Market St &amp; 9th St\" lat=\"37.77741\"
+        lon=\"-122.4163399\" stopId=\"15652\"/>\n<stop tag=\"5651\" title=\"Market
+        St &amp; 8th St\" lat=\"37.77861\" lon=\"-122.4148299\" stopId=\"15651\"/>\n<stop
+        tag=\"5650\" title=\"Market St &amp; 7th St\" lat=\"37.7803599\" lon=\"-122.41261\"
+        stopId=\"15650\"/>\n<stop tag=\"5647\" title=\"Market St &amp; 6th St\" lat=\"37.7820999\"
+        lon=\"-122.4104\" stopId=\"15647\"/>\n<stop tag=\"5645\" title=\"Market St
+        &amp; 5th St\" lat=\"37.7838899\" lon=\"-122.40814\" stopId=\"15645\"/>\n<stop
+        tag=\"5643\" title=\"Market St &amp; 4th St\" lat=\"37.7856499\" lon=\"-122.40589\"
+        stopId=\"15643\"/>\n<stop tag=\"5640\" title=\"Market St &amp; 3rd St\" lat=\"37.7875299\"
+        lon=\"-122.40352\" stopId=\"15640\"/>\n<stop tag=\"5685\" title=\"Market St
+        &amp; New Montgomery St\" lat=\"37.7886099\" lon=\"-122.40216\" stopId=\"15685\"/>\n<stop
+        tag=\"7264\" title=\"Market St &amp; 1st St\" lat=\"37.79094\" lon=\"-122.3991899\"
+        stopId=\"17264\"/>\n<stop tag=\"5658\" title=\"Market St &amp; Beale St\"
+        lat=\"37.79257\" lon=\"-122.3970199\" stopId=\"15658\"/>\n<stop tag=\"6475\"
+        title=\"Spear St &amp; Market St\" lat=\"37.7935899\" lon=\"-122.3955499\"
+        stopId=\"16475\"/>\n<stop tag=\"36497\" title=\"Steuart St &amp; Mission St\"
+        lat=\"37.7933499\" lon=\"-122.39323\" stopId=\"136497\"/>\n<stop tag=\"4733\"
+        title=\"Fulton St &amp; 6th Ave\" lat=\"37.7735299\" lon=\"-122.46384\" stopId=\"14733\"/>\n<stop
+        tag=\"3089\" title=\"Beale St &amp; Mission St\" lat=\"37.7917499\" lon=\"-122.3967\"
+        stopId=\"13089\"/>\n<direction tag=\"21_IB1\" title=\"Inbound to Downtown\"
+        name=\"Inbound\" useForUI=\"true\">\n  <stop tag=\"7499\" />\n  <stop tag=\"7561\"
+        />\n  <stop tag=\"4988\" />\n  <stop tag=\"5002\" />\n  <stop tag=\"4986\"
+        />\n  <stop tag=\"5000\" />\n  <stop tag=\"4980\" />\n  <stop tag=\"4992\"
+        />\n  <stop tag=\"5004\" />\n  <stop tag=\"5012\" />\n  <stop tag=\"4994\"
+        />\n  <stop tag=\"5015\" />\n  <stop tag=\"4984\" />\n  <stop tag=\"5260\"
+        />\n  <stop tag=\"4921\" />\n  <stop tag=\"4920\" />\n  <stop tag=\"4923\"
+        />\n  <stop tag=\"7463\" />\n  <stop tag=\"5652\" />\n  <stop tag=\"5651\"
+        />\n  <stop tag=\"5650\" />\n  <stop tag=\"5647\" />\n  <stop tag=\"5645\"
+        />\n  <stop tag=\"5643\" />\n  <stop tag=\"5640\" />\n  <stop tag=\"5685\"
+        />\n  <stop tag=\"7264\" />\n  <stop tag=\"5658\" />\n  <stop tag=\"6475\"
+        />\n  <stop tag=\"36497\" />\n</direction>\n<direction tag=\"21_OB4\" title=\"Outbound
+        to Golden Gate Park\" name=\"Outbound\" useForUI=\"true\">\n  <stop tag=\"6497\"
+        />\n  <stop tag=\"6501\" />\n  <stop tag=\"5669\" />\n  <stop tag=\"5671\"
+        />\n  <stop tag=\"5689\" />\n  <stop tag=\"5684\" />\n  <stop tag=\"5674\"
+        />\n  <stop tag=\"5688\" />\n  <stop tag=\"5683\" />\n  <stop tag=\"5656\"
+        />\n  <stop tag=\"7423\" />\n  <stop tag=\"4997\" />\n  <stop tag=\"5013\"
+        />\n  <stop tag=\"4996\" />\n  <stop tag=\"4998\" />\n  <stop tag=\"4983\"
+        />\n  <stop tag=\"5014\" />\n  <stop tag=\"4993\" />\n  <stop tag=\"5011\"
+        />\n  <stop tag=\"5003\" />\n  <stop tag=\"4991\" />\n  <stop tag=\"4979\"
+        />\n  <stop tag=\"4999\" />\n  <stop tag=\"4985\" />\n  <stop tag=\"5001\"
+        />\n  <stop tag=\"4987\" />\n  <stop tag=\"5007\" />\n  <stop tag=\"5009\"
+        />\n  <stop tag=\"37499\" />\n</direction>\n<path>\n<point lat=\"37.775\"
+        lon=\"-122.4374\"/>\n<point lat=\"37.77541\" lon=\"-122.43418\"/>\n<point
+        lat=\"37.77563\" lon=\"-122.43248\"/>\n<point lat=\"37.7757999\" lon=\"-122.43083\"/>\n<point
+        lat=\"37.77604\" lon=\"-122.42919\"/>\n<point lat=\"37.77624\" lon=\"-122.42755\"/>\n<point
+        lat=\"37.77646\" lon=\"-122.42627\"/>\n<point lat=\"37.77675\" lon=\"-122.42627\"/>\n<point
+        lat=\"37.7773899\" lon=\"-122.42646\"/>\n<point lat=\"37.77738\" lon=\"-122.42632\"/>\n<point
+        lat=\"37.77775\" lon=\"-122.42331\"/>\n<point lat=\"37.77819\" lon=\"-122.41974\"/>\n</path>\n<path>\n<point
+        lat=\"37.77487\" lon=\"-122.45309\"/>\n<point lat=\"37.77496\" lon=\"-122.45299\"/>\n<point
+        lat=\"37.7731\" lon=\"-122.45262\"/>\n<point lat=\"37.77306\" lon=\"-122.45251\"/>\n<point
+        lat=\"37.77342\" lon=\"-122.44946\"/>\n<point lat=\"37.77395\" lon=\"-122.44568\"/>\n</path>\n<path>\n<point
+        lat=\"37.77819\" lon=\"-122.41974\"/>\n<point lat=\"37.77848\" lon=\"-122.41823\"/>\n<point
+        lat=\"37.77838\" lon=\"-122.41831\"/>\n<point lat=\"37.7768\" lon=\"-122.4179\"/>\n<point
+        lat=\"37.77654\" lon=\"-122.41751\"/>\n<point lat=\"37.77741\" lon=\"-122.41634\"/>\n<point
+        lat=\"37.77861\" lon=\"-122.41483\"/>\n<point lat=\"37.78036\" lon=\"-122.41261\"/>\n</path>\n<path>\n<point
+        lat=\"37.7856499\" lon=\"-122.40589\"/>\n<point lat=\"37.7875299\" lon=\"-122.40352\"/>\n<point
+        lat=\"37.78861\" lon=\"-122.40216\"/>\n</path>\n<path>\n<point lat=\"37.77393\"
+        lon=\"-122.44651\"/>\n<point lat=\"37.77361\" lon=\"-122.44917\"/>\n<point
+        lat=\"37.77317\" lon=\"-122.4525\"/>\n<point lat=\"37.77296\" lon=\"-122.45415\"/>\n<point
+        lat=\"37.7728899\" lon=\"-122.45428\"/>\n<point lat=\"37.77464\" lon=\"-122.45463\"/>\n<point
+        lat=\"37.7749\" lon=\"-122.45346\"/>\n<point lat=\"37.77487\" lon=\"-122.45309\"/>\n</path>\n<path>\n<point
+        lat=\"37.78036\" lon=\"-122.41261\"/>\n<point lat=\"37.7821\" lon=\"-122.4104\"/>\n<point
+        lat=\"37.78389\" lon=\"-122.40814\"/>\n<point lat=\"37.7856499\" lon=\"-122.40589\"/>\n</path>\n<path>\n<point
+        lat=\"37.77487\" lon=\"-122.45309\"/>\n<point lat=\"37.7731\" lon=\"-122.45262\"/>\n<point
+        lat=\"37.77306\" lon=\"-122.45251\"/>\n<point lat=\"37.77342\" lon=\"-122.44946\"/>\n<point
+        lat=\"37.77395\" lon=\"-122.44568\"/>\n</path>\n<path>\n<point lat=\"37.77499\"
+        lon=\"-122.43818\"/>\n<point lat=\"37.77457\" lon=\"-122.4415\"/>\n<point
+        lat=\"37.77443\" lon=\"-122.44263\"/>\n<point lat=\"37.7742\" lon=\"-122.4443\"/>\n<point
+        lat=\"37.77393\" lon=\"-122.44651\"/>\n</path>\n<path>\n<point lat=\"37.77729\"
+        lon=\"-122.42019\"/>\n<point lat=\"37.77689\" lon=\"-122.42333\"/>\n<point
+        lat=\"37.77653\" lon=\"-122.42615\"/>\n<point lat=\"37.77626\" lon=\"-122.42827\"/>\n<point
+        lat=\"37.77606\" lon=\"-122.42988\"/>\n<point lat=\"37.77584\" lon=\"-122.43156\"/>\n<point
+        lat=\"37.77563\" lon=\"-122.4332\"/>\n<point lat=\"37.77547\" lon=\"-122.43444\"/>\n<point
+        lat=\"37.77499\" lon=\"-122.43818\"/>\n</path>\n<path>\n<point lat=\"37.78468\"
+        lon=\"-122.40731\"/>\n<point lat=\"37.78285\" lon=\"-122.40964\"/>\n<point
+        lat=\"37.78057\" lon=\"-122.41244\"/>\n</path>\n<path>\n<point lat=\"37.78861\"
+        lon=\"-122.40216\"/>\n<point lat=\"37.79094\" lon=\"-122.39919\"/>\n<point
+        lat=\"37.79257\" lon=\"-122.39702\"/>\n<point lat=\"37.79378\" lon=\"-122.39563\"/>\n<point
+        lat=\"37.79359\" lon=\"-122.39555\"/>\n<point lat=\"37.79254\" lon=\"-122.39407\"/>\n<point
+        lat=\"37.79322\" lon=\"-122.39319\"/>\n<point lat=\"37.7933499\" lon=\"-122.39323\"/>\n</path>\n<path>\n<point
+        lat=\"37.7933499\" lon=\"-122.39323\"/>\n<point lat=\"37.79443\" lon=\"-122.39455\"/>\n<point
+        lat=\"37.7944699\" lon=\"-122.39476\"/>\n<point lat=\"37.79347\" lon=\"-122.39618\"/>\n<point
+        lat=\"37.79192\" lon=\"-122.39815\"/>\n<point lat=\"37.79016\" lon=\"-122.40041\"/>\n</path>\n<path>\n<point
+        lat=\"37.79016\" lon=\"-122.40041\"/>\n<point lat=\"37.78849\" lon=\"-122.40248\"/>\n<point
+        lat=\"37.78639\" lon=\"-122.40516\"/>\n<point lat=\"37.78468\" lon=\"-122.40731\"/>\n</path>\n<path>\n<point
+        lat=\"37.78861\" lon=\"-122.40216\"/>\n<point lat=\"37.7924\" lon=\"-122.39739\"/>\n<point
+        lat=\"37.79175\" lon=\"-122.3967\"/>\n</path>\n<path>\n<point lat=\"37.77353\"
+        lon=\"-122.46384\"/>\n<point lat=\"37.77487\" lon=\"-122.45309\"/>\n</path>\n<path>\n<point
+        lat=\"37.77395\" lon=\"-122.44568\"/>\n<point lat=\"37.77409\" lon=\"-122.44451\"/>\n<point
+        lat=\"37.77429\" lon=\"-122.44286\"/>\n<point lat=\"37.77451\" lon=\"-122.44126\"/>\n<point
+        lat=\"37.775\" lon=\"-122.4374\"/>\n</path>\n<path>\n<point lat=\"37.78057\"
+        lon=\"-122.41244\"/>\n<point lat=\"37.77878\" lon=\"-122.41472\"/>\n<point
+        lat=\"37.77779\" lon=\"-122.41593\"/>\n<point lat=\"37.77771\" lon=\"-122.41685\"/>\n<point
+        lat=\"37.77729\" lon=\"-122.42019\"/>\n</path>\n</route>\n</body>\n"
+    http_version: 
+  recorded_at: Tue, 26 Mar 2013 19:41:23 GMT
+recorded_with: VCR 2.4.0

--- a/spec/cassettes/Muni_Direction/_stop_at/given_an_exact_stop_title/should_return_corresponding_stop.yml
+++ b/spec/cassettes/Muni_Direction/_stop_at/given_an_exact_stop_title/should_return_corresponding_stop.yml
@@ -1,0 +1,430 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://webservices.nextbus.com/service/publicXMLFeed?a=sf-muni&command=routeConfig&r=2424
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - '*/*'
+      User-Agent:
+      - Ruby
+      Host:
+      - webservices.nextbus.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 Mar 2013 19:47:39 GMT
+      Server:
+      - Apache/2.2.4 (Unix) mod_ssl/2.2.4 OpenSSL/0.9.7m DAV/2 mod_jk/1.2.30
+      Access-Control-Allow-Origin:
+      - '*'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '202'
+      Content-Type:
+      - text/xml
+      X-Pad:
+      - avoid browser bug
+    body:
+      encoding: UTF-8
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\" ?> \n<body copyright=\"All
+        data copyright San Francisco Muni 2013.\">\n<Error shouldRetry=\"false\">\n
+        \ Could not get route \"2424\" for agency tag \"sf-muni\". \nOne of the tags
+        could be bad.\n</Error>\n</body>\n"
+    http_version: 
+  recorded_at: Tue, 26 Mar 2013 19:47:39 GMT
+- request:
+    method: get
+    uri: http://webservices.nextbus.com/service/publicXMLFeed?a=sf-muni&command=routeConfig&r=24
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - '*/*'
+      User-Agent:
+      - Ruby
+      Host:
+      - webservices.nextbus.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 Mar 2013 19:47:56 GMT
+      Server:
+      - Apache/2.2.4 (Unix) mod_ssl/2.2.4 OpenSSL/0.9.7m DAV/2 mod_jk/1.2.30
+      Access-Control-Allow-Origin:
+      - '*'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4048'
+      Content-Type:
+      - text/xml
+      X-Pad:
+      - avoid browser bug
+    body:
+      encoding: UTF-8
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\" ?> \n<body copyright=\"All
+        data copyright San Francisco Muni 2013.\">\n<route tag=\"24\" title=\"24-Divisadero\"
+        color=\"996699\" oppositeColor=\"000000\" latMin=\"37.7340899\" latMax=\"37.7927199\"
+        lonMin=\"-122.44108\" lonMax=\"-122.39093\">\n<stop tag=\"3541\" title=\"30th
+        St &amp; Mission St\" lat=\"37.7423099\" lon=\"-122.42217\" stopId=\"13541\"/>\n<stop
+        tag=\"4157\" title=\"Cortland Ave &amp; Mission St\" lat=\"37.74085\" lon=\"-122.42251\"
+        stopId=\"14157\"/>\n<stop tag=\"4161\" title=\"Cortland Ave &amp; Prospect
+        Ave\" lat=\"37.7402\" lon=\"-122.42093\" stopId=\"14161\"/>\n<stop tag=\"4150\"
+        title=\"Cortland Ave &amp; Elsie St\" lat=\"37.7397\" lon=\"-122.41969\" stopId=\"14150\"/>\n<stop
+        tag=\"4146\" title=\"Cortland Ave &amp; Bocana St\" lat=\"37.7393099\" lon=\"-122.4187199\"
+        stopId=\"14146\"/>\n<stop tag=\"4143\" title=\"Cortland Ave &amp; Andover
+        St\" lat=\"37.7390399\" lon=\"-122.4165799\" stopId=\"14143\"/>\n<stop tag=\"4152\"
+        title=\"Cortland Ave &amp; Ellsworth St\" lat=\"37.73883\" lon=\"-122.41461\"
+        stopId=\"14152\"/>\n<stop tag=\"4154\" title=\"Cortland Ave &amp; Folsom St\"
+        lat=\"37.73892\" lon=\"-122.4134299\" stopId=\"14154\"/>\n<stop tag=\"4159\"
+        title=\"Cortland Ave &amp; Prentiss St\" lat=\"37.7395699\" lon=\"-122.41211\"
+        stopId=\"14159\"/>\n<stop tag=\"7213\" title=\"Cortland Ave &amp; Bronte St\"
+        lat=\"37.7397099\" lon=\"-122.4101699\" stopId=\"17213\"/>\n<stop tag=\"4148\"
+        title=\"Cortland Ave &amp; Bayshore Blvd\" lat=\"37.7395399\" lon=\"-122.4072\"
+        stopId=\"14148\"/>\n<stop tag=\"5093\" title=\"Industrial St &amp; Bayshore
+        Blvd\" lat=\"37.73794\" lon=\"-122.4067799\" stopId=\"15093\"/>\n<stop tag=\"5094\"
+        title=\"Industrial St &amp; Elmira St\" lat=\"37.73879\" lon=\"-122.4037299\"
+        stopId=\"15094\"/>\n<stop tag=\"5095\" title=\"Industrial St &amp; Palou Ave\"
+        lat=\"37.73955\" lon=\"-122.4010099\" stopId=\"15095\"/>\n<stop tag=\"5884\"
+        title=\"Palou Ave &amp; Rankin St\" lat=\"37.73825\" lon=\"-122.39853\" stopId=\"15884\"/>\n<stop
+        tag=\"5882\" title=\"Palou Ave &amp; Quint St\" lat=\"37.73722\" lon=\"-122.39672\"
+        stopId=\"15882\"/>\n<stop tag=\"5880\" title=\"Palou Ave &amp; Phelps St\"
+        lat=\"37.7360999\" lon=\"-122.3948099\" stopId=\"15880\"/>\n<stop tag=\"5878\"
+        title=\"Palou Ave &amp; Newhall St\" lat=\"37.7350299\" lon=\"-122.3926599\"
+        stopId=\"15878\"/>\n<stop tag=\"33141\" title=\"3rd St &amp; Palou Ave\" lat=\"37.7340899\"
+        lon=\"-122.39093\" stopId=\"133141\"/>\n<stop tag=\"5167\" title=\"Jackson
+        St &amp; Webster St\" lat=\"37.7927199\" lon=\"-122.43302\" stopId=\"15167\"/>\n<stop
+        tag=\"5147\" title=\"Jackson St &amp; Fillmore St\" lat=\"37.7925299\" lon=\"-122.43468\"
+        stopId=\"15147\"/>\n<stop tag=\"5162\" title=\"Jackson St &amp; Steiner St\"
+        lat=\"37.7923499\" lon=\"-122.43611\" stopId=\"15162\"/>\n<stop tag=\"5160\"
+        title=\"Jackson St &amp; Scott St\" lat=\"37.7919299\" lon=\"-122.43924\"
+        stopId=\"15160\"/>\n<stop tag=\"5145\" title=\"Jackson St &amp; Divisadero
+        St\" lat=\"37.79172\" lon=\"-122.4408899\" stopId=\"15145\"/>\n<stop tag=\"4413\"
+        title=\"Divisadero St &amp; Clay St\" lat=\"37.7899699\" lon=\"-122.4408899\"
+        stopId=\"14413\"/>\n<stop tag=\"4410\" title=\"Divisadero St &amp; California
+        St\" lat=\"37.7879899\" lon=\"-122.4404999\" stopId=\"14410\"/>\n<stop tag=\"4433\"
+        title=\"Divisadero St &amp; Pine St\" lat=\"37.7869999\" lon=\"-122.4403199\"
+        stopId=\"14433\"/>\n<stop tag=\"4435\" title=\"Divisadero St &amp; Sutter
+        St\" lat=\"37.7851499\" lon=\"-122.43994\" stopId=\"14435\"/>\n<stop tag=\"4422\"
+        title=\"Divisadero St &amp; Geary Blvd\" lat=\"37.78316\" lon=\"-122.43953\"
+        stopId=\"14422\"/>\n<stop tag=\"4415\" title=\"Divisadero St &amp; Eddy St\"
+        lat=\"37.7804499\" lon=\"-122.43898\" stopId=\"14415\"/>\n<stop tag=\"4429\"
+        title=\"Divisadero St &amp; McAllister St\" lat=\"37.77768\" lon=\"-122.43841\"
+        stopId=\"14429\"/>\n<stop tag=\"4426\" title=\"Divisadero St &amp; Hayes St\"
+        lat=\"37.77489\" lon=\"-122.43786\" stopId=\"14426\"/>\n<stop tag=\"4432\"
+        title=\"Divisadero St &amp; Oak St\" lat=\"37.77305\" lon=\"-122.43749\" stopId=\"14432\"/>\n<stop
+        tag=\"4424\" title=\"Divisadero St &amp; Haight St\" lat=\"37.7710499\" lon=\"-122.4371\"
+        stopId=\"14424\"/>\n<stop tag=\"4330\" title=\"Castro St &amp; Duboce Ave\"
+        lat=\"37.76918\" lon=\"-122.4359599\" stopId=\"14330\"/>\n<stop tag=\"4308\"
+        title=\"Castro St &amp; 14th St\" lat=\"37.7674199\" lon=\"-122.4357099\"
+        stopId=\"14308\"/>\n<stop tag=\"4309\" title=\"Castro St &amp; 15th St\" lat=\"37.76583\"
+        lon=\"-122.43557\" stopId=\"14309\"/>\n<stop tag=\"4312\" title=\"Castro St
+        &amp; 16th St\" lat=\"37.76427\" lon=\"-122.43544\" stopId=\"14312\"/>\n<stop
+        tag=\"4334\" title=\"Castro St &amp; Market St\" lat=\"37.76214\" lon=\"-122.43519\"
+        stopId=\"14334\"/>\n<stop tag=\"4315\" title=\"Castro St &amp; 18th St\" lat=\"37.7607499\"
+        lon=\"-122.43507\" stopId=\"14315\"/>\n<stop tag=\"4316\" title=\"Castro St
+        &amp; 19th St\" lat=\"37.75939\" lon=\"-122.43491\" stopId=\"14316\"/>\n<stop
+        tag=\"4318\" title=\"Castro St &amp; 20th St\" lat=\"37.75778\" lon=\"-122.43477\"
+        stopId=\"14318\"/>\n<stop tag=\"4321\" title=\"Castro St &amp; 21st St\" lat=\"37.7560999\"
+        lon=\"-122.4346199\" stopId=\"14321\"/>\n<stop tag=\"4322\" title=\"Castro
+        St &amp; 22nd St\" lat=\"37.75464\" lon=\"-122.43448\" stopId=\"14322\"/>\n<stop
+        tag=\"4325\" title=\"Castro St &amp; 23rd St\" lat=\"37.7528999\" lon=\"-122.4343199\"
+        stopId=\"14325\"/>\n<stop tag=\"4333\" title=\"Castro St &amp; Elizabeth St\"
+        lat=\"37.7520799\" lon=\"-122.4342499\" stopId=\"14333\"/>\n<stop tag=\"4327\"
+        title=\"Castro St &amp; 24th St\" lat=\"37.7512499\" lon=\"-122.43418\" stopId=\"14327\"/>\n<stop
+        tag=\"4328\" title=\"Castro St &amp; 25th St\" lat=\"37.74981\" lon=\"-122.43404\"
+        stopId=\"14328\"/>\n<stop tag=\"7290\" title=\"Castro St &amp; 26th St\" lat=\"37.7481999\"
+        lon=\"-122.4338899\" stopId=\"17290\"/>\n<stop tag=\"3521\" title=\"26th St
+        &amp; Noe St\" lat=\"37.74817\" lon=\"-122.4316399\" stopId=\"13521\"/>\n<stop
+        tag=\"5732\" title=\"Noe St &amp; 27th St\" lat=\"37.7466799\" lon=\"-122.4314799\"
+        stopId=\"15732\"/>\n<stop tag=\"5734\" title=\"Noe St &amp; 28th St\" lat=\"37.74519\"
+        lon=\"-122.43134\" stopId=\"15734\"/>\n<stop tag=\"5736\" title=\"Noe St &amp;
+        29th St\" lat=\"37.74354\" lon=\"-122.43117\" stopId=\"15736\"/>\n<stop tag=\"5738\"
+        title=\"Noe St &amp; 30th St\" lat=\"37.74201\" lon=\"-122.43101\" stopId=\"15738\"/>\n<stop
+        tag=\"3544\" title=\"30th St &amp; Sanchez St\" lat=\"37.7419099\" lon=\"-122.42902\"
+        stopId=\"13544\"/>\n<stop tag=\"3536\" title=\"30th St &amp; Church St\" lat=\"37.7420399\"
+        lon=\"-122.42676\" stopId=\"13536\"/>\n<stop tag=\"3538\" title=\"30th St
+        &amp; Dolores St\" lat=\"37.7421699\" lon=\"-122.42446\" stopId=\"13538\"/>\n<stop
+        tag=\"34148\" title=\"Cortland Ave &amp; Bayshore Blvd\" lat=\"37.7395399\"
+        lon=\"-122.4072\" stopId=\"134148\"/>\n<stop tag=\"4314\" title=\"Castro St
+        &amp; 18th St\" lat=\"37.7608399\" lon=\"-122.43493\" stopId=\"14314\"/>\n<stop
+        tag=\"4313\" title=\"Castro St &amp; 17th St\" lat=\"37.76237\" lon=\"-122.43508\"
+        stopId=\"14313\"/>\n<stop tag=\"4311\" title=\"Castro St &amp; 16th St\" lat=\"37.76416\"
+        lon=\"-122.43525\" stopId=\"14311\"/>\n<stop tag=\"4310\" title=\"Castro St
+        &amp; 15th St\" lat=\"37.7656099\" lon=\"-122.4353799\" stopId=\"14310\"/>\n<stop
+        tag=\"4307\" title=\"Castro St &amp; 14th St\" lat=\"37.76761\" lon=\"-122.43558\"
+        stopId=\"14307\"/>\n<stop tag=\"4331\" title=\"Castro St &amp; Duboce Ave\"
+        lat=\"37.76895\" lon=\"-122.43571\" stopId=\"14331\"/>\n<stop tag=\"4423\"
+        title=\"Divisadero St &amp; Haight St\" lat=\"37.7713299\" lon=\"-122.43698\"
+        stopId=\"14423\"/>\n<stop tag=\"4431\" title=\"Divisadero St &amp; Oak St\"
+        lat=\"37.77319\" lon=\"-122.43735\" stopId=\"14431\"/>\n<stop tag=\"4425\"
+        title=\"Divisadero St &amp; Hayes St\" lat=\"37.77506\" lon=\"-122.43774\"
+        stopId=\"14425\"/>\n<stop tag=\"4428\" title=\"Divisadero St &amp; McAllister
+        St\" lat=\"37.7778599\" lon=\"-122.4382999\" stopId=\"14428\"/>\n<stop tag=\"4414\"
+        title=\"Divisadero St &amp; Eddy St\" lat=\"37.7804999\" lon=\"-122.43881\"
+        stopId=\"14414\"/>\n<stop tag=\"4421\" title=\"Divisadero St &amp; Geary Blvd\"
+        lat=\"37.78338\" lon=\"-122.43941\" stopId=\"14421\"/>\n<stop tag=\"4434\"
+        title=\"Divisadero St &amp; Sutter St\" lat=\"37.7853399\" lon=\"-122.43981\"
+        stopId=\"14434\"/>\n<stop tag=\"4408\" title=\"Divisadero St &amp; Bush St\"
+        lat=\"37.78628\" lon=\"-122.44\" stopId=\"14408\"/>\n<stop tag=\"4409\" title=\"Divisadero
+        St &amp; California St\" lat=\"37.7881799\" lon=\"-122.4403799\" stopId=\"14409\"/>\n<stop
+        tag=\"4412\" title=\"Divisadero St &amp; Clay St\" lat=\"37.7899799\" lon=\"-122.4407399\"
+        stopId=\"14412\"/>\n<stop tag=\"4427\" title=\"Divisadero St &amp; Jackson
+        St\" lat=\"37.79154\" lon=\"-122.44108\" stopId=\"14427\"/>\n<stop tag=\"5161\"
+        title=\"Jackson St &amp; Scott St\" lat=\"37.7917699\" lon=\"-122.43961\"
+        stopId=\"15161\"/>\n<stop tag=\"5163\" title=\"Jackson St &amp; Steiner St\"
+        lat=\"37.7921999\" lon=\"-122.43632\" stopId=\"15163\"/>\n<stop tag=\"4624\"
+        title=\"Fillmore St &amp; Jackson St\" lat=\"37.7923899\" lon=\"-122.4346099\"
+        stopId=\"14624\"/>\n<stop tag=\"6931\" title=\"Washington St &amp; Webster
+        St\" lat=\"37.7917199\" lon=\"-122.43284\" stopId=\"16931\"/>\n<stop tag=\"35167\"
+        title=\"Jackson St &amp; Webster St\" lat=\"37.7927199\" lon=\"-122.43302\"
+        stopId=\"135167\"/>\n<stop tag=\"3141\" title=\"3rd St &amp; Palou Ave\" lat=\"37.7340899\"
+        lon=\"-122.39093\" stopId=\"13141\"/>\n<stop tag=\"5490\" title=\"Newcomb
+        Ave &amp; Newhall St\" lat=\"37.7362999\" lon=\"-122.3915199\" stopId=\"15490\"/>\n<stop
+        tag=\"5491\" title=\"Newhall St &amp; Oakdale Ave\" lat=\"37.7357999\" lon=\"-122.39217\"
+        stopId=\"15491\"/>\n<stop tag=\"5492\" title=\"Newhall St &amp; Palou Ave\"
+        lat=\"37.73517\" lon=\"-122.3927399\" stopId=\"15492\"/>\n<stop tag=\"5879\"
+        title=\"Palou Ave &amp; Phelps St\" lat=\"37.7360999\" lon=\"-122.3945299\"
+        stopId=\"15879\"/>\n<stop tag=\"5881\" title=\"Palou Ave &amp; Quint St\"
+        lat=\"37.7371599\" lon=\"-122.3963699\" stopId=\"15881\"/>\n<stop tag=\"5883\"
+        title=\"Palou Ave &amp; Rankin St\" lat=\"37.73821\" lon=\"-122.39824\" stopId=\"15883\"/>\n<stop
+        tag=\"5867\" title=\"Palou Ave &amp; Industrial St\" lat=\"37.7395299\" lon=\"-122.4005499\"
+        stopId=\"15867\"/>\n<stop tag=\"5096\" title=\"Industrial St &amp; Revere
+        Ave\" lat=\"37.73913\" lon=\"-122.4030499\" stopId=\"15096\"/>\n<stop tag=\"5092\"
+        title=\"Industrial St &amp; Bayshore Blvd\" lat=\"37.7381499\" lon=\"-122.40654\"
+        stopId=\"15092\"/>\n<stop tag=\"4155\" title=\"Cortland Ave &amp; Hilton St\"
+        lat=\"37.7396899\" lon=\"-122.40781\" stopId=\"14155\"/>\n<stop tag=\"4147\"
+        title=\"Cortland Ave &amp; Bradford St\" lat=\"37.7397899\" lon=\"-122.4097499\"
+        stopId=\"14147\"/>\n<stop tag=\"4158\" title=\"Cortland Ave &amp; Prentiss
+        St\" lat=\"37.7397799\" lon=\"-122.41199\" stopId=\"14158\"/>\n<stop tag=\"4153\"
+        title=\"Cortland Ave &amp; Folsom St\" lat=\"37.739\" lon=\"-122.4136599\"
+        stopId=\"14153\"/>\n<stop tag=\"4151\" title=\"Cortland Ave &amp; Ellsworth
+        St\" lat=\"37.7389199\" lon=\"-122.41455\" stopId=\"14151\"/>\n<stop tag=\"4142\"
+        title=\"Cortland Ave &amp; Andover St\" lat=\"37.7390899\" lon=\"-122.4163899\"
+        stopId=\"14142\"/>\n<stop tag=\"4145\" title=\"Cortland Ave &amp; Bocana St\"
+        lat=\"37.7393\" lon=\"-122.41846\" stopId=\"14145\"/>\n<stop tag=\"4149\"
+        title=\"Cortland Ave &amp; Elsie St\" lat=\"37.73992\" lon=\"-122.41997\"
+        stopId=\"14149\"/>\n<stop tag=\"4160\" title=\"Cortland Ave &amp; Prospect
+        Ave\" lat=\"37.74029\" lon=\"-122.4209\" stopId=\"14160\"/>\n<stop tag=\"4156\"
+        title=\"Cortland Ave &amp; Mission St\" lat=\"37.7410099\" lon=\"-122.4226699\"
+        stopId=\"14156\"/>\n<stop tag=\"3540\" title=\"30th St &amp; Mission St\"
+        lat=\"37.7424399\" lon=\"-122.42206\" stopId=\"13540\"/>\n<stop tag=\"3537\"
+        title=\"30th St &amp; Dolores St\" lat=\"37.7423\" lon=\"-122.4240299\" stopId=\"13537\"/>\n<stop
+        tag=\"3535\" title=\"30th St &amp; Church St\" lat=\"37.74216\" lon=\"-122.4263699\"
+        stopId=\"13535\"/>\n<stop tag=\"3543\" title=\"30th St &amp; Sanchez St\"
+        lat=\"37.7420199\" lon=\"-122.4286\" stopId=\"13543\"/>\n<stop tag=\"3542\"
+        title=\"30th St &amp; Noe St\" lat=\"37.7418799\" lon=\"-122.43079\" stopId=\"13542\"/>\n<stop
+        tag=\"5737\" title=\"Noe St &amp; 29th St\" lat=\"37.7433\" lon=\"-122.43104\"
+        stopId=\"15737\"/>\n<stop tag=\"5735\" title=\"Noe St &amp; 28th St\" lat=\"37.7449299\"
+        lon=\"-122.4311699\" stopId=\"15735\"/>\n<stop tag=\"5733\" title=\"Noe St
+        &amp; 27th St\" lat=\"37.7465399\" lon=\"-122.4313199\" stopId=\"15733\"/>\n<stop
+        tag=\"3520\" title=\"26th St &amp; Noe St\" lat=\"37.7482699\" lon=\"-122.43177\"
+        stopId=\"13520\"/>\n<stop tag=\"3514\" title=\"26th St &amp; Castro St\" lat=\"37.74815\"
+        lon=\"-122.4336299\" stopId=\"13514\"/>\n<stop tag=\"4329\" title=\"Castro
+        St &amp; 25th St\" lat=\"37.7495999\" lon=\"-122.4338299\" stopId=\"14329\"/>\n<stop
+        tag=\"4326\" title=\"Castro St &amp; 24th St\" lat=\"37.7511999\" lon=\"-122.43401\"
+        stopId=\"14326\"/>\n<stop tag=\"4332\" title=\"Castro St &amp; Elizabeth St\"
+        lat=\"37.75189\" lon=\"-122.43405\" stopId=\"14332\"/>\n<stop tag=\"4324\"
+        title=\"Castro St &amp; 23rd St\" lat=\"37.75278\" lon=\"-122.43416\" stopId=\"14324\"/>\n<stop
+        tag=\"4323\" title=\"Castro St &amp; 22nd St\" lat=\"37.75441\" lon=\"-122.43431\"
+        stopId=\"14323\"/>\n<stop tag=\"4320\" title=\"Castro St &amp; 21st St\" lat=\"37.7559599\"
+        lon=\"-122.4344599\" stopId=\"14320\"/>\n<stop tag=\"4319\" title=\"Castro
+        St &amp; 20th St\" lat=\"37.7576299\" lon=\"-122.4346399\" stopId=\"14319\"/>\n<stop
+        tag=\"4317\" title=\"Castro St &amp; 19th St\" lat=\"37.7591599\" lon=\"-122.4347899\"
+        stopId=\"14317\"/>\n<stop tag=\"34435\" title=\"Divisadero St &amp; Sutter
+        St\" lat=\"37.7851499\" lon=\"-122.43994\" stopId=\"134435\"/>\n<stop tag=\"14148\"
+        title=\"Cortland Ave &amp; Bayshore Blvd\" lat=\"37.7395399\" lon=\"-122.4072\"
+        stopId=\"114148\"/>\n<direction tag=\"24_OB3\" title=\"Outbound to the Bayview
+        District\" name=\"Outbound\" useForUI=\"true\">\n  <stop tag=\"5167\" />\n
+        \ <stop tag=\"5147\" />\n  <stop tag=\"5162\" />\n  <stop tag=\"5160\" />\n
+        \ <stop tag=\"5145\" />\n  <stop tag=\"4413\" />\n  <stop tag=\"4410\" />\n
+        \ <stop tag=\"4433\" />\n  <stop tag=\"4435\" />\n  <stop tag=\"4422\" />\n
+        \ <stop tag=\"4415\" />\n  <stop tag=\"4429\" />\n  <stop tag=\"4426\" />\n
+        \ <stop tag=\"4432\" />\n  <stop tag=\"4424\" />\n  <stop tag=\"4330\" />\n
+        \ <stop tag=\"4308\" />\n  <stop tag=\"4309\" />\n  <stop tag=\"4312\" />\n
+        \ <stop tag=\"4334\" />\n  <stop tag=\"4315\" />\n  <stop tag=\"4316\" />\n
+        \ <stop tag=\"4318\" />\n  <stop tag=\"4321\" />\n  <stop tag=\"4322\" />\n
+        \ <stop tag=\"4325\" />\n  <stop tag=\"4333\" />\n  <stop tag=\"4327\" />\n
+        \ <stop tag=\"4328\" />\n  <stop tag=\"7290\" />\n  <stop tag=\"3521\" />\n
+        \ <stop tag=\"5732\" />\n  <stop tag=\"5734\" />\n  <stop tag=\"5736\" />\n
+        \ <stop tag=\"5738\" />\n  <stop tag=\"3544\" />\n  <stop tag=\"3536\" />\n
+        \ <stop tag=\"3538\" />\n  <stop tag=\"3541\" />\n  <stop tag=\"4157\" />\n
+        \ <stop tag=\"4161\" />\n  <stop tag=\"4150\" />\n  <stop tag=\"4146\" />\n
+        \ <stop tag=\"4143\" />\n  <stop tag=\"4152\" />\n  <stop tag=\"4154\" />\n
+        \ <stop tag=\"4159\" />\n  <stop tag=\"7213\" />\n  <stop tag=\"4148\" />\n
+        \ <stop tag=\"5093\" />\n  <stop tag=\"5094\" />\n  <stop tag=\"5095\" />\n
+        \ <stop tag=\"5884\" />\n  <stop tag=\"5882\" />\n  <stop tag=\"5880\" />\n
+        \ <stop tag=\"5878\" />\n  <stop tag=\"33141\" />\n</direction>\n<direction
+        tag=\"24_IB1\" title=\"Inbound to Pacific Heights\" name=\"Inbound\" useForUI=\"true\">\n
+        \ <stop tag=\"3141\" />\n  <stop tag=\"5490\" />\n  <stop tag=\"5491\" />\n
+        \ <stop tag=\"5492\" />\n  <stop tag=\"5879\" />\n  <stop tag=\"5881\" />\n
+        \ <stop tag=\"5883\" />\n  <stop tag=\"5867\" />\n  <stop tag=\"5096\" />\n
+        \ <stop tag=\"5092\" />\n  <stop tag=\"4155\" />\n  <stop tag=\"4147\" />\n
+        \ <stop tag=\"4158\" />\n  <stop tag=\"4153\" />\n  <stop tag=\"4151\" />\n
+        \ <stop tag=\"4142\" />\n  <stop tag=\"4145\" />\n  <stop tag=\"4149\" />\n
+        \ <stop tag=\"4160\" />\n  <stop tag=\"4156\" />\n  <stop tag=\"3540\" />\n
+        \ <stop tag=\"3537\" />\n  <stop tag=\"3535\" />\n  <stop tag=\"3543\" />\n
+        \ <stop tag=\"3542\" />\n  <stop tag=\"5737\" />\n  <stop tag=\"5735\" />\n
+        \ <stop tag=\"5733\" />\n  <stop tag=\"3520\" />\n  <stop tag=\"3514\" />\n
+        \ <stop tag=\"4329\" />\n  <stop tag=\"4326\" />\n  <stop tag=\"4332\" />\n
+        \ <stop tag=\"4324\" />\n  <stop tag=\"4323\" />\n  <stop tag=\"4320\" />\n
+        \ <stop tag=\"4319\" />\n  <stop tag=\"4317\" />\n  <stop tag=\"4314\" />\n
+        \ <stop tag=\"4313\" />\n  <stop tag=\"4311\" />\n  <stop tag=\"4310\" />\n
+        \ <stop tag=\"4307\" />\n  <stop tag=\"4331\" />\n  <stop tag=\"4423\" />\n
+        \ <stop tag=\"4431\" />\n  <stop tag=\"4425\" />\n  <stop tag=\"4428\" />\n
+        \ <stop tag=\"4414\" />\n  <stop tag=\"4421\" />\n  <stop tag=\"4434\" />\n
+        \ <stop tag=\"4408\" />\n  <stop tag=\"4409\" />\n  <stop tag=\"4412\" />\n
+        \ <stop tag=\"4427\" />\n  <stop tag=\"5161\" />\n  <stop tag=\"5163\" />\n
+        \ <stop tag=\"4624\" />\n  <stop tag=\"6931\" />\n  <stop tag=\"35167\" />\n</direction>\n<path>\n<point
+        lat=\"37.7805\" lon=\"-122.43881\"/>\n<point lat=\"37.78515\" lon=\"-122.43994\"/>\n</path>\n<path>\n<point
+        lat=\"37.77105\" lon=\"-122.4371\"/>\n<point lat=\"37.77034\" lon=\"-122.43686\"/>\n<point
+        lat=\"37.76996\" lon=\"-122.43632\"/>\n<point lat=\"37.76975\" lon=\"-122.4362\"/>\n<point
+        lat=\"37.76938\" lon=\"-122.43592\"/>\n<point lat=\"37.76918\" lon=\"-122.43596\"/>\n<point
+        lat=\"37.76906\" lon=\"-122.4358\"/>\n<point lat=\"37.76742\" lon=\"-122.43571\"/>\n<point
+        lat=\"37.76583\" lon=\"-122.43557\"/>\n<point lat=\"37.76427\" lon=\"-122.43544\"/>\n<point
+        lat=\"37.76214\" lon=\"-122.43519\"/>\n<point lat=\"37.76075\" lon=\"-122.43507\"/>\n</path>\n<path>\n<point
+        lat=\"37.74231\" lon=\"-122.42217\"/>\n<point lat=\"37.74103\" lon=\"-122.42285\"/>\n<point
+        lat=\"37.74085\" lon=\"-122.42251\"/>\n<point lat=\"37.7402\" lon=\"-122.42093\"/>\n<point
+        lat=\"37.7397\" lon=\"-122.41969\"/>\n<point lat=\"37.73931\" lon=\"-122.41872\"/>\n<point
+        lat=\"37.7393\" lon=\"-122.41859\"/>\n<point lat=\"37.73904\" lon=\"-122.41658\"/>\n<point
+        lat=\"37.73888\" lon=\"-122.41467\"/>\n<point lat=\"37.73883\" lon=\"-122.41461\"/>\n<point
+        lat=\"37.73892\" lon=\"-122.41343\"/>\n<point lat=\"37.73897\" lon=\"-122.41341\"/>\n<point
+        lat=\"37.73931\" lon=\"-122.41267\"/>\n<point lat=\"37.73957\" lon=\"-122.41211\"/>\n<point
+        lat=\"37.7398499\" lon=\"-122.41175\"/>\n<point lat=\"37.73971\" lon=\"-122.41017\"/>\n<point
+        lat=\"37.73954\" lon=\"-122.4072\"/>\n</path>\n<path>\n<point lat=\"37.73954\"
+        lon=\"-122.4072\"/>\n<point lat=\"37.73907\" lon=\"-122.40712\"/>\n<point
+        lat=\"37.7388199\" lon=\"-122.40726\"/>\n<point lat=\"37.73888\" lon=\"-122.40755\"/>\n<point
+        lat=\"37.73934\" lon=\"-122.40766\"/>\n<point lat=\"37.73961\" lon=\"-122.40765\"/>\n<point
+        lat=\"37.73969\" lon=\"-122.40781\"/>\n</path>\n<path>\n<point lat=\"37.7805\"
+        lon=\"-122.43881\"/>\n<point lat=\"37.78338\" lon=\"-122.43941\"/>\n<point
+        lat=\"37.78534\" lon=\"-122.43981\"/>\n</path>\n<path>\n<point lat=\"37.73969\"
+        lon=\"-122.40781\"/>\n<point lat=\"37.73979\" lon=\"-122.40975\"/>\n<point
+        lat=\"37.7398499\" lon=\"-122.41175\"/>\n<point lat=\"37.73978\" lon=\"-122.41199\"/>\n<point
+        lat=\"37.739\" lon=\"-122.41319\"/>\n<point lat=\"37.739\" lon=\"-122.41366\"/>\n<point
+        lat=\"37.73892\" lon=\"-122.41455\"/>\n<point lat=\"37.73888\" lon=\"-122.41457\"/>\n<point
+        lat=\"37.73909\" lon=\"-122.41639\"/>\n<point lat=\"37.73925\" lon=\"-122.41846\"/>\n<point
+        lat=\"37.7393\" lon=\"-122.41846\"/>\n<point lat=\"37.73992\" lon=\"-122.41997\"/>\n<point
+        lat=\"37.74029\" lon=\"-122.4209\"/>\n<point lat=\"37.74101\" lon=\"-122.42267\"/>\n<point
+        lat=\"37.74103\" lon=\"-122.42285\"/>\n<point lat=\"37.74244\" lon=\"-122.42206\"/>\n</path>\n<path>\n<point
+        lat=\"37.74244\" lon=\"-122.42206\"/>\n<point lat=\"37.7423\" lon=\"-122.42329\"/>\n<point
+        lat=\"37.7423\" lon=\"-122.42403\"/>\n<point lat=\"37.74216\" lon=\"-122.42637\"/>\n<point
+        lat=\"37.7420199\" lon=\"-122.4286\"/>\n<point lat=\"37.74188\" lon=\"-122.43079\"/>\n<point
+        lat=\"37.74184\" lon=\"-122.43089\"/>\n<point lat=\"37.7433\" lon=\"-122.43104\"/>\n<point
+        lat=\"37.7449299\" lon=\"-122.43117\"/>\n<point lat=\"37.74654\" lon=\"-122.43132\"/>\n<point
+        lat=\"37.74814\" lon=\"-122.43154\"/>\n<point lat=\"37.74827\" lon=\"-122.43177\"/>\n<point
+        lat=\"37.74815\" lon=\"-122.43363\"/>\n<point lat=\"37.7481\" lon=\"-122.43378\"/>\n<point
+        lat=\"37.7496\" lon=\"-122.43383\"/>\n<point lat=\"37.7512\" lon=\"-122.43401\"/>\n</path>\n<path>\n<point
+        lat=\"37.76075\" lon=\"-122.43507\"/>\n<point lat=\"37.75939\" lon=\"-122.43491\"/>\n<point
+        lat=\"37.7577799\" lon=\"-122.43477\"/>\n<point lat=\"37.7561\" lon=\"-122.43462\"/>\n<point
+        lat=\"37.75464\" lon=\"-122.43448\"/>\n<point lat=\"37.7528999\" lon=\"-122.43432\"/>\n<point
+        lat=\"37.75208\" lon=\"-122.43425\"/>\n<point lat=\"37.75125\" lon=\"-122.43418\"/>\n</path>\n<path>\n<point
+        lat=\"37.73409\" lon=\"-122.39093\"/>\n<point lat=\"37.73559\" lon=\"-122.39042\"/>\n<point
+        lat=\"37.7363\" lon=\"-122.39152\"/>\n<point lat=\"37.7363\" lon=\"-122.39165\"/>\n<point
+        lat=\"37.7358\" lon=\"-122.39217\"/>\n<point lat=\"37.7351699\" lon=\"-122.39274\"/>\n<point
+        lat=\"37.73504\" lon=\"-122.39278\"/>\n<point lat=\"37.7361\" lon=\"-122.39453\"/>\n<point
+        lat=\"37.73716\" lon=\"-122.39637\"/>\n<point lat=\"37.73821\" lon=\"-122.39824\"/>\n<point
+        lat=\"37.73953\" lon=\"-122.40055\"/>\n<point lat=\"37.73966\" lon=\"-122.4009\"/>\n<point
+        lat=\"37.73913\" lon=\"-122.40305\"/>\n<point lat=\"37.73815\" lon=\"-122.40654\"/>\n<point
+        lat=\"37.73797\" lon=\"-122.40692\"/>\n<point lat=\"37.73846\" lon=\"-122.40707\"/>\n<point
+        lat=\"37.73907\" lon=\"-122.40712\"/>\n<point lat=\"37.73932\" lon=\"-122.40708\"/>\n<point
+        lat=\"37.73957\" lon=\"-122.40698\"/>\n<point lat=\"37.73969\" lon=\"-122.40781\"/>\n</path>\n<path>\n<point
+        lat=\"37.77133\" lon=\"-122.43698\"/>\n<point lat=\"37.77319\" lon=\"-122.43735\"/>\n<point
+        lat=\"37.77506\" lon=\"-122.43774\"/>\n<point lat=\"37.7778599\" lon=\"-122.4383\"/>\n<point
+        lat=\"37.7805\" lon=\"-122.43881\"/>\n</path>\n<path>\n<point lat=\"37.78534\"
+        lon=\"-122.43981\"/>\n<point lat=\"37.78628\" lon=\"-122.44\"/>\n<point lat=\"37.7881799\"
+        lon=\"-122.44038\"/>\n<point lat=\"37.78998\" lon=\"-122.44074\"/>\n<point
+        lat=\"37.79154\" lon=\"-122.44108\"/>\n<point lat=\"37.79163\" lon=\"-122.44116\"/>\n<point
+        lat=\"37.79177\" lon=\"-122.43961\"/>\n<point lat=\"37.7922\" lon=\"-122.43632\"/>\n<point
+        lat=\"37.79247\" lon=\"-122.43456\"/>\n<point lat=\"37.79239\" lon=\"-122.43461\"/>\n<point
+        lat=\"37.79158\" lon=\"-122.43439\"/>\n<point lat=\"37.79172\" lon=\"-122.43284\"/>\n<point
+        lat=\"37.7918\" lon=\"-122.43275\"/>\n<point lat=\"37.79267\" lon=\"-122.43292\"/>\n<point
+        lat=\"37.79272\" lon=\"-122.43302\"/>\n</path>\n<path>\n<point lat=\"37.76084\"
+        lon=\"-122.43493\"/>\n<point lat=\"37.76237\" lon=\"-122.43508\"/>\n<point
+        lat=\"37.7641599\" lon=\"-122.43525\"/>\n<point lat=\"37.76561\" lon=\"-122.43538\"/>\n<point
+        lat=\"37.76761\" lon=\"-122.43558\"/>\n<point lat=\"37.7689499\" lon=\"-122.43571\"/>\n<point
+        lat=\"37.76906\" lon=\"-122.4358\"/>\n<point lat=\"37.76938\" lon=\"-122.43592\"/>\n<point
+        lat=\"37.76975\" lon=\"-122.4362\"/>\n<point lat=\"37.76996\" lon=\"-122.43632\"/>\n<point
+        lat=\"37.77029\" lon=\"-122.43678\"/>\n<point lat=\"37.77133\" lon=\"-122.43698\"/>\n</path>\n<path>\n<point
+        lat=\"37.73954\" lon=\"-122.4072\"/>\n<point lat=\"37.73957\" lon=\"-122.40698\"/>\n<point
+        lat=\"37.73932\" lon=\"-122.40708\"/>\n<point lat=\"37.73907\" lon=\"-122.40712\"/>\n<point
+        lat=\"37.7381\" lon=\"-122.40701\"/>\n<point lat=\"37.73794\" lon=\"-122.40678\"/>\n<point
+        lat=\"37.73833\" lon=\"-122.40566\"/>\n<point lat=\"37.73879\" lon=\"-122.40373\"/>\n<point
+        lat=\"37.73955\" lon=\"-122.40101\"/>\n<point lat=\"37.73966\" lon=\"-122.4009\"/>\n<point
+        lat=\"37.73825\" lon=\"-122.39853\"/>\n<point lat=\"37.73722\" lon=\"-122.39672\"/>\n<point
+        lat=\"37.7361\" lon=\"-122.39481\"/>\n<point lat=\"37.73503\" lon=\"-122.39266\"/>\n<point
+        lat=\"37.73409\" lon=\"-122.39093\"/>\n</path>\n<path>\n<point lat=\"37.78045\"
+        lon=\"-122.43898\"/>\n<point lat=\"37.7776799\" lon=\"-122.43841\"/>\n<point
+        lat=\"37.77489\" lon=\"-122.43786\"/>\n<point lat=\"37.77305\" lon=\"-122.43749\"/>\n<point
+        lat=\"37.77105\" lon=\"-122.4371\"/>\n</path>\n<path>\n<point lat=\"37.78515\"
+        lon=\"-122.43994\"/>\n<point lat=\"37.78316\" lon=\"-122.43953\"/>\n<point
+        lat=\"37.78045\" lon=\"-122.43898\"/>\n</path>\n<path>\n<point lat=\"37.75125\"
+        lon=\"-122.43418\"/>\n<point lat=\"37.7498099\" lon=\"-122.43404\"/>\n<point
+        lat=\"37.7482\" lon=\"-122.43389\"/>\n<point lat=\"37.7481\" lon=\"-122.43378\"/>\n<point
+        lat=\"37.74817\" lon=\"-122.43164\"/>\n<point lat=\"37.74823\" lon=\"-122.43157\"/>\n<point
+        lat=\"37.74668\" lon=\"-122.43148\"/>\n<point lat=\"37.74519\" lon=\"-122.43134\"/>\n<point
+        lat=\"37.74354\" lon=\"-122.43117\"/>\n<point lat=\"37.74201\" lon=\"-122.43101\"/>\n<point
+        lat=\"37.74192\" lon=\"-122.43096\"/>\n<point lat=\"37.74189\" lon=\"-122.42995\"/>\n<point
+        lat=\"37.74191\" lon=\"-122.42902\"/>\n<point lat=\"37.74204\" lon=\"-122.42676\"/>\n<point
+        lat=\"37.74217\" lon=\"-122.42446\"/>\n<point lat=\"37.74231\" lon=\"-122.42217\"/>\n</path>\n<path>\n<point
+        lat=\"37.73969\" lon=\"-122.40781\"/>\n<point lat=\"37.73979\" lon=\"-122.40975\"/>\n<point
+        lat=\"37.7398499\" lon=\"-122.41175\"/>\n<point lat=\"37.73978\" lon=\"-122.41199\"/>\n<point
+        lat=\"37.739\" lon=\"-122.41319\"/>\n<point lat=\"37.739\" lon=\"-122.41366\"/>\n<point
+        lat=\"37.73892\" lon=\"-122.41455\"/>\n<point lat=\"37.73888\" lon=\"-122.41457\"/>\n<point
+        lat=\"37.73909\" lon=\"-122.41639\"/>\n<point lat=\"37.73925\" lon=\"-122.41846\"/>\n<point
+        lat=\"37.7393\" lon=\"-122.41846\"/>\n<point lat=\"37.73992\" lon=\"-122.41997\"/>\n<point
+        lat=\"37.74029\" lon=\"-122.4209\"/>\n<point lat=\"37.74101\" lon=\"-122.42267\"/>\n<point
+        lat=\"37.74103\" lon=\"-122.42285\"/>\n<point lat=\"37.7421999\" lon=\"-122.42209\"/>\n<point
+        lat=\"37.74244\" lon=\"-122.42206\"/>\n</path>\n<path>\n<point lat=\"37.7512\"
+        lon=\"-122.43401\"/>\n<point lat=\"37.75189\" lon=\"-122.43405\"/>\n<point
+        lat=\"37.75278\" lon=\"-122.43416\"/>\n<point lat=\"37.75441\" lon=\"-122.43431\"/>\n<point
+        lat=\"37.75596\" lon=\"-122.43446\"/>\n<point lat=\"37.75763\" lon=\"-122.43464\"/>\n<point
+        lat=\"37.75916\" lon=\"-122.43479\"/>\n<point lat=\"37.76084\" lon=\"-122.43493\"/>\n</path>\n<path>\n<point
+        lat=\"37.73409\" lon=\"-122.39093\"/>\n<point lat=\"37.73559\" lon=\"-122.39042\"/>\n<point
+        lat=\"37.7363\" lon=\"-122.39152\"/>\n<point lat=\"37.7363\" lon=\"-122.39165\"/>\n<point
+        lat=\"37.7358\" lon=\"-122.39217\"/>\n<point lat=\"37.7351699\" lon=\"-122.39274\"/>\n<point
+        lat=\"37.73504\" lon=\"-122.39278\"/>\n<point lat=\"37.73566\" lon=\"-122.39222\"/>\n<point
+        lat=\"37.73504\" lon=\"-122.39278\"/>\n<point lat=\"37.7361\" lon=\"-122.39453\"/>\n<point
+        lat=\"37.73716\" lon=\"-122.39637\"/>\n<point lat=\"37.73821\" lon=\"-122.39824\"/>\n<point
+        lat=\"37.73953\" lon=\"-122.40055\"/>\n<point lat=\"37.73966\" lon=\"-122.4009\"/>\n<point
+        lat=\"37.73913\" lon=\"-122.40305\"/>\n<point lat=\"37.73815\" lon=\"-122.40654\"/>\n<point
+        lat=\"37.73797\" lon=\"-122.40692\"/>\n<point lat=\"37.73846\" lon=\"-122.40707\"/>\n<point
+        lat=\"37.73907\" lon=\"-122.40712\"/>\n<point lat=\"37.73932\" lon=\"-122.40708\"/>\n<point
+        lat=\"37.73957\" lon=\"-122.40698\"/>\n<point lat=\"37.73969\" lon=\"-122.40781\"/>\n</path>\n<path>\n<point
+        lat=\"37.7805\" lon=\"-122.43881\"/>\n<point lat=\"37.78534\" lon=\"-122.43981\"/>\n</path>\n<path>\n<point
+        lat=\"37.74231\" lon=\"-122.42217\"/>\n<point lat=\"37.74238\" lon=\"-122.42198\"/>\n<point
+        lat=\"37.74103\" lon=\"-122.42285\"/>\n<point lat=\"37.74085\" lon=\"-122.42251\"/>\n<point
+        lat=\"37.7402\" lon=\"-122.42093\"/>\n<point lat=\"37.7397\" lon=\"-122.41969\"/>\n<point
+        lat=\"37.73931\" lon=\"-122.41872\"/>\n<point lat=\"37.7393\" lon=\"-122.41859\"/>\n<point
+        lat=\"37.73904\" lon=\"-122.41658\"/>\n<point lat=\"37.73888\" lon=\"-122.41467\"/>\n<point
+        lat=\"37.73883\" lon=\"-122.41461\"/>\n<point lat=\"37.73892\" lon=\"-122.41343\"/>\n<point
+        lat=\"37.73897\" lon=\"-122.41341\"/>\n<point lat=\"37.73931\" lon=\"-122.41267\"/>\n<point
+        lat=\"37.73957\" lon=\"-122.41211\"/>\n<point lat=\"37.7398499\" lon=\"-122.41175\"/>\n<point
+        lat=\"37.73971\" lon=\"-122.41017\"/>\n<point lat=\"37.73954\" lon=\"-122.4072\"/>\n</path>\n<path>\n<point
+        lat=\"37.79272\" lon=\"-122.43302\"/>\n<point lat=\"37.79253\" lon=\"-122.43468\"/>\n<point
+        lat=\"37.79235\" lon=\"-122.43611\"/>\n<point lat=\"37.79193\" lon=\"-122.43924\"/>\n<point
+        lat=\"37.79172\" lon=\"-122.44089\"/>\n<point lat=\"37.79163\" lon=\"-122.44116\"/>\n<point
+        lat=\"37.7899699\" lon=\"-122.44089\"/>\n<point lat=\"37.78799\" lon=\"-122.4405\"/>\n<point
+        lat=\"37.787\" lon=\"-122.44032\"/>\n<point lat=\"37.78515\" lon=\"-122.43994\"/>\n</path>\n<path>\n<point
+        lat=\"37.78534\" lon=\"-122.43981\"/>\n<point lat=\"37.78628\" lon=\"-122.44\"/>\n<point
+        lat=\"37.7881799\" lon=\"-122.44038\"/>\n<point lat=\"37.78998\" lon=\"-122.44074\"/>\n<point
+        lat=\"37.79154\" lon=\"-122.44108\"/>\n<point lat=\"37.79163\" lon=\"-122.44116\"/>\n<point
+        lat=\"37.79177\" lon=\"-122.43961\"/>\n<point lat=\"37.7922\" lon=\"-122.43632\"/>\n</path>\n</route>\n</body>\n"
+    http_version: 
+  recorded_at: Tue, 26 Mar 2013 19:47:56 GMT
+recorded_with: VCR 2.4.0

--- a/spec/cassettes/Muni_Direction/_stop_at/given_an_inexact_stop_title/should_return_a_corresponding_stop.yml
+++ b/spec/cassettes/Muni_Direction/_stop_at/given_an_inexact_stop_title/should_return_a_corresponding_stop.yml
@@ -1,0 +1,430 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://webservices.nextbus.com/service/publicXMLFeed?a=sf-muni&command=routeConfig&r=2424
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - '*/*'
+      User-Agent:
+      - Ruby
+      Host:
+      - webservices.nextbus.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 Mar 2013 19:47:39 GMT
+      Server:
+      - Apache/2.2.4 (Unix) mod_ssl/2.2.4 OpenSSL/0.9.7m DAV/2 mod_jk/1.2.30
+      Access-Control-Allow-Origin:
+      - '*'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '202'
+      Content-Type:
+      - text/xml
+      X-Pad:
+      - avoid browser bug
+    body:
+      encoding: UTF-8
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\" ?> \n<body copyright=\"All
+        data copyright San Francisco Muni 2013.\">\n<Error shouldRetry=\"false\">\n
+        \ Could not get route \"2424\" for agency tag \"sf-muni\". \nOne of the tags
+        could be bad.\n</Error>\n</body>\n"
+    http_version: 
+  recorded_at: Tue, 26 Mar 2013 19:47:39 GMT
+- request:
+    method: get
+    uri: http://webservices.nextbus.com/service/publicXMLFeed?a=sf-muni&command=routeConfig&r=24
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - '*/*'
+      User-Agent:
+      - Ruby
+      Host:
+      - webservices.nextbus.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 Mar 2013 19:47:56 GMT
+      Server:
+      - Apache/2.2.4 (Unix) mod_ssl/2.2.4 OpenSSL/0.9.7m DAV/2 mod_jk/1.2.30
+      Access-Control-Allow-Origin:
+      - '*'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4048'
+      Content-Type:
+      - text/xml
+      X-Pad:
+      - avoid browser bug
+    body:
+      encoding: UTF-8
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\" ?> \n<body copyright=\"All
+        data copyright San Francisco Muni 2013.\">\n<route tag=\"24\" title=\"24-Divisadero\"
+        color=\"996699\" oppositeColor=\"000000\" latMin=\"37.7340899\" latMax=\"37.7927199\"
+        lonMin=\"-122.44108\" lonMax=\"-122.39093\">\n<stop tag=\"3541\" title=\"30th
+        St &amp; Mission St\" lat=\"37.7423099\" lon=\"-122.42217\" stopId=\"13541\"/>\n<stop
+        tag=\"4157\" title=\"Cortland Ave &amp; Mission St\" lat=\"37.74085\" lon=\"-122.42251\"
+        stopId=\"14157\"/>\n<stop tag=\"4161\" title=\"Cortland Ave &amp; Prospect
+        Ave\" lat=\"37.7402\" lon=\"-122.42093\" stopId=\"14161\"/>\n<stop tag=\"4150\"
+        title=\"Cortland Ave &amp; Elsie St\" lat=\"37.7397\" lon=\"-122.41969\" stopId=\"14150\"/>\n<stop
+        tag=\"4146\" title=\"Cortland Ave &amp; Bocana St\" lat=\"37.7393099\" lon=\"-122.4187199\"
+        stopId=\"14146\"/>\n<stop tag=\"4143\" title=\"Cortland Ave &amp; Andover
+        St\" lat=\"37.7390399\" lon=\"-122.4165799\" stopId=\"14143\"/>\n<stop tag=\"4152\"
+        title=\"Cortland Ave &amp; Ellsworth St\" lat=\"37.73883\" lon=\"-122.41461\"
+        stopId=\"14152\"/>\n<stop tag=\"4154\" title=\"Cortland Ave &amp; Folsom St\"
+        lat=\"37.73892\" lon=\"-122.4134299\" stopId=\"14154\"/>\n<stop tag=\"4159\"
+        title=\"Cortland Ave &amp; Prentiss St\" lat=\"37.7395699\" lon=\"-122.41211\"
+        stopId=\"14159\"/>\n<stop tag=\"7213\" title=\"Cortland Ave &amp; Bronte St\"
+        lat=\"37.7397099\" lon=\"-122.4101699\" stopId=\"17213\"/>\n<stop tag=\"4148\"
+        title=\"Cortland Ave &amp; Bayshore Blvd\" lat=\"37.7395399\" lon=\"-122.4072\"
+        stopId=\"14148\"/>\n<stop tag=\"5093\" title=\"Industrial St &amp; Bayshore
+        Blvd\" lat=\"37.73794\" lon=\"-122.4067799\" stopId=\"15093\"/>\n<stop tag=\"5094\"
+        title=\"Industrial St &amp; Elmira St\" lat=\"37.73879\" lon=\"-122.4037299\"
+        stopId=\"15094\"/>\n<stop tag=\"5095\" title=\"Industrial St &amp; Palou Ave\"
+        lat=\"37.73955\" lon=\"-122.4010099\" stopId=\"15095\"/>\n<stop tag=\"5884\"
+        title=\"Palou Ave &amp; Rankin St\" lat=\"37.73825\" lon=\"-122.39853\" stopId=\"15884\"/>\n<stop
+        tag=\"5882\" title=\"Palou Ave &amp; Quint St\" lat=\"37.73722\" lon=\"-122.39672\"
+        stopId=\"15882\"/>\n<stop tag=\"5880\" title=\"Palou Ave &amp; Phelps St\"
+        lat=\"37.7360999\" lon=\"-122.3948099\" stopId=\"15880\"/>\n<stop tag=\"5878\"
+        title=\"Palou Ave &amp; Newhall St\" lat=\"37.7350299\" lon=\"-122.3926599\"
+        stopId=\"15878\"/>\n<stop tag=\"33141\" title=\"3rd St &amp; Palou Ave\" lat=\"37.7340899\"
+        lon=\"-122.39093\" stopId=\"133141\"/>\n<stop tag=\"5167\" title=\"Jackson
+        St &amp; Webster St\" lat=\"37.7927199\" lon=\"-122.43302\" stopId=\"15167\"/>\n<stop
+        tag=\"5147\" title=\"Jackson St &amp; Fillmore St\" lat=\"37.7925299\" lon=\"-122.43468\"
+        stopId=\"15147\"/>\n<stop tag=\"5162\" title=\"Jackson St &amp; Steiner St\"
+        lat=\"37.7923499\" lon=\"-122.43611\" stopId=\"15162\"/>\n<stop tag=\"5160\"
+        title=\"Jackson St &amp; Scott St\" lat=\"37.7919299\" lon=\"-122.43924\"
+        stopId=\"15160\"/>\n<stop tag=\"5145\" title=\"Jackson St &amp; Divisadero
+        St\" lat=\"37.79172\" lon=\"-122.4408899\" stopId=\"15145\"/>\n<stop tag=\"4413\"
+        title=\"Divisadero St &amp; Clay St\" lat=\"37.7899699\" lon=\"-122.4408899\"
+        stopId=\"14413\"/>\n<stop tag=\"4410\" title=\"Divisadero St &amp; California
+        St\" lat=\"37.7879899\" lon=\"-122.4404999\" stopId=\"14410\"/>\n<stop tag=\"4433\"
+        title=\"Divisadero St &amp; Pine St\" lat=\"37.7869999\" lon=\"-122.4403199\"
+        stopId=\"14433\"/>\n<stop tag=\"4435\" title=\"Divisadero St &amp; Sutter
+        St\" lat=\"37.7851499\" lon=\"-122.43994\" stopId=\"14435\"/>\n<stop tag=\"4422\"
+        title=\"Divisadero St &amp; Geary Blvd\" lat=\"37.78316\" lon=\"-122.43953\"
+        stopId=\"14422\"/>\n<stop tag=\"4415\" title=\"Divisadero St &amp; Eddy St\"
+        lat=\"37.7804499\" lon=\"-122.43898\" stopId=\"14415\"/>\n<stop tag=\"4429\"
+        title=\"Divisadero St &amp; McAllister St\" lat=\"37.77768\" lon=\"-122.43841\"
+        stopId=\"14429\"/>\n<stop tag=\"4426\" title=\"Divisadero St &amp; Hayes St\"
+        lat=\"37.77489\" lon=\"-122.43786\" stopId=\"14426\"/>\n<stop tag=\"4432\"
+        title=\"Divisadero St &amp; Oak St\" lat=\"37.77305\" lon=\"-122.43749\" stopId=\"14432\"/>\n<stop
+        tag=\"4424\" title=\"Divisadero St &amp; Haight St\" lat=\"37.7710499\" lon=\"-122.4371\"
+        stopId=\"14424\"/>\n<stop tag=\"4330\" title=\"Castro St &amp; Duboce Ave\"
+        lat=\"37.76918\" lon=\"-122.4359599\" stopId=\"14330\"/>\n<stop tag=\"4308\"
+        title=\"Castro St &amp; 14th St\" lat=\"37.7674199\" lon=\"-122.4357099\"
+        stopId=\"14308\"/>\n<stop tag=\"4309\" title=\"Castro St &amp; 15th St\" lat=\"37.76583\"
+        lon=\"-122.43557\" stopId=\"14309\"/>\n<stop tag=\"4312\" title=\"Castro St
+        &amp; 16th St\" lat=\"37.76427\" lon=\"-122.43544\" stopId=\"14312\"/>\n<stop
+        tag=\"4334\" title=\"Castro St &amp; Market St\" lat=\"37.76214\" lon=\"-122.43519\"
+        stopId=\"14334\"/>\n<stop tag=\"4315\" title=\"Castro St &amp; 18th St\" lat=\"37.7607499\"
+        lon=\"-122.43507\" stopId=\"14315\"/>\n<stop tag=\"4316\" title=\"Castro St
+        &amp; 19th St\" lat=\"37.75939\" lon=\"-122.43491\" stopId=\"14316\"/>\n<stop
+        tag=\"4318\" title=\"Castro St &amp; 20th St\" lat=\"37.75778\" lon=\"-122.43477\"
+        stopId=\"14318\"/>\n<stop tag=\"4321\" title=\"Castro St &amp; 21st St\" lat=\"37.7560999\"
+        lon=\"-122.4346199\" stopId=\"14321\"/>\n<stop tag=\"4322\" title=\"Castro
+        St &amp; 22nd St\" lat=\"37.75464\" lon=\"-122.43448\" stopId=\"14322\"/>\n<stop
+        tag=\"4325\" title=\"Castro St &amp; 23rd St\" lat=\"37.7528999\" lon=\"-122.4343199\"
+        stopId=\"14325\"/>\n<stop tag=\"4333\" title=\"Castro St &amp; Elizabeth St\"
+        lat=\"37.7520799\" lon=\"-122.4342499\" stopId=\"14333\"/>\n<stop tag=\"4327\"
+        title=\"Castro St &amp; 24th St\" lat=\"37.7512499\" lon=\"-122.43418\" stopId=\"14327\"/>\n<stop
+        tag=\"4328\" title=\"Castro St &amp; 25th St\" lat=\"37.74981\" lon=\"-122.43404\"
+        stopId=\"14328\"/>\n<stop tag=\"7290\" title=\"Castro St &amp; 26th St\" lat=\"37.7481999\"
+        lon=\"-122.4338899\" stopId=\"17290\"/>\n<stop tag=\"3521\" title=\"26th St
+        &amp; Noe St\" lat=\"37.74817\" lon=\"-122.4316399\" stopId=\"13521\"/>\n<stop
+        tag=\"5732\" title=\"Noe St &amp; 27th St\" lat=\"37.7466799\" lon=\"-122.4314799\"
+        stopId=\"15732\"/>\n<stop tag=\"5734\" title=\"Noe St &amp; 28th St\" lat=\"37.74519\"
+        lon=\"-122.43134\" stopId=\"15734\"/>\n<stop tag=\"5736\" title=\"Noe St &amp;
+        29th St\" lat=\"37.74354\" lon=\"-122.43117\" stopId=\"15736\"/>\n<stop tag=\"5738\"
+        title=\"Noe St &amp; 30th St\" lat=\"37.74201\" lon=\"-122.43101\" stopId=\"15738\"/>\n<stop
+        tag=\"3544\" title=\"30th St &amp; Sanchez St\" lat=\"37.7419099\" lon=\"-122.42902\"
+        stopId=\"13544\"/>\n<stop tag=\"3536\" title=\"30th St &amp; Church St\" lat=\"37.7420399\"
+        lon=\"-122.42676\" stopId=\"13536\"/>\n<stop tag=\"3538\" title=\"30th St
+        &amp; Dolores St\" lat=\"37.7421699\" lon=\"-122.42446\" stopId=\"13538\"/>\n<stop
+        tag=\"34148\" title=\"Cortland Ave &amp; Bayshore Blvd\" lat=\"37.7395399\"
+        lon=\"-122.4072\" stopId=\"134148\"/>\n<stop tag=\"4314\" title=\"Castro St
+        &amp; 18th St\" lat=\"37.7608399\" lon=\"-122.43493\" stopId=\"14314\"/>\n<stop
+        tag=\"4313\" title=\"Castro St &amp; 17th St\" lat=\"37.76237\" lon=\"-122.43508\"
+        stopId=\"14313\"/>\n<stop tag=\"4311\" title=\"Castro St &amp; 16th St\" lat=\"37.76416\"
+        lon=\"-122.43525\" stopId=\"14311\"/>\n<stop tag=\"4310\" title=\"Castro St
+        &amp; 15th St\" lat=\"37.7656099\" lon=\"-122.4353799\" stopId=\"14310\"/>\n<stop
+        tag=\"4307\" title=\"Castro St &amp; 14th St\" lat=\"37.76761\" lon=\"-122.43558\"
+        stopId=\"14307\"/>\n<stop tag=\"4331\" title=\"Castro St &amp; Duboce Ave\"
+        lat=\"37.76895\" lon=\"-122.43571\" stopId=\"14331\"/>\n<stop tag=\"4423\"
+        title=\"Divisadero St &amp; Haight St\" lat=\"37.7713299\" lon=\"-122.43698\"
+        stopId=\"14423\"/>\n<stop tag=\"4431\" title=\"Divisadero St &amp; Oak St\"
+        lat=\"37.77319\" lon=\"-122.43735\" stopId=\"14431\"/>\n<stop tag=\"4425\"
+        title=\"Divisadero St &amp; Hayes St\" lat=\"37.77506\" lon=\"-122.43774\"
+        stopId=\"14425\"/>\n<stop tag=\"4428\" title=\"Divisadero St &amp; McAllister
+        St\" lat=\"37.7778599\" lon=\"-122.4382999\" stopId=\"14428\"/>\n<stop tag=\"4414\"
+        title=\"Divisadero St &amp; Eddy St\" lat=\"37.7804999\" lon=\"-122.43881\"
+        stopId=\"14414\"/>\n<stop tag=\"4421\" title=\"Divisadero St &amp; Geary Blvd\"
+        lat=\"37.78338\" lon=\"-122.43941\" stopId=\"14421\"/>\n<stop tag=\"4434\"
+        title=\"Divisadero St &amp; Sutter St\" lat=\"37.7853399\" lon=\"-122.43981\"
+        stopId=\"14434\"/>\n<stop tag=\"4408\" title=\"Divisadero St &amp; Bush St\"
+        lat=\"37.78628\" lon=\"-122.44\" stopId=\"14408\"/>\n<stop tag=\"4409\" title=\"Divisadero
+        St &amp; California St\" lat=\"37.7881799\" lon=\"-122.4403799\" stopId=\"14409\"/>\n<stop
+        tag=\"4412\" title=\"Divisadero St &amp; Clay St\" lat=\"37.7899799\" lon=\"-122.4407399\"
+        stopId=\"14412\"/>\n<stop tag=\"4427\" title=\"Divisadero St &amp; Jackson
+        St\" lat=\"37.79154\" lon=\"-122.44108\" stopId=\"14427\"/>\n<stop tag=\"5161\"
+        title=\"Jackson St &amp; Scott St\" lat=\"37.7917699\" lon=\"-122.43961\"
+        stopId=\"15161\"/>\n<stop tag=\"5163\" title=\"Jackson St &amp; Steiner St\"
+        lat=\"37.7921999\" lon=\"-122.43632\" stopId=\"15163\"/>\n<stop tag=\"4624\"
+        title=\"Fillmore St &amp; Jackson St\" lat=\"37.7923899\" lon=\"-122.4346099\"
+        stopId=\"14624\"/>\n<stop tag=\"6931\" title=\"Washington St &amp; Webster
+        St\" lat=\"37.7917199\" lon=\"-122.43284\" stopId=\"16931\"/>\n<stop tag=\"35167\"
+        title=\"Jackson St &amp; Webster St\" lat=\"37.7927199\" lon=\"-122.43302\"
+        stopId=\"135167\"/>\n<stop tag=\"3141\" title=\"3rd St &amp; Palou Ave\" lat=\"37.7340899\"
+        lon=\"-122.39093\" stopId=\"13141\"/>\n<stop tag=\"5490\" title=\"Newcomb
+        Ave &amp; Newhall St\" lat=\"37.7362999\" lon=\"-122.3915199\" stopId=\"15490\"/>\n<stop
+        tag=\"5491\" title=\"Newhall St &amp; Oakdale Ave\" lat=\"37.7357999\" lon=\"-122.39217\"
+        stopId=\"15491\"/>\n<stop tag=\"5492\" title=\"Newhall St &amp; Palou Ave\"
+        lat=\"37.73517\" lon=\"-122.3927399\" stopId=\"15492\"/>\n<stop tag=\"5879\"
+        title=\"Palou Ave &amp; Phelps St\" lat=\"37.7360999\" lon=\"-122.3945299\"
+        stopId=\"15879\"/>\n<stop tag=\"5881\" title=\"Palou Ave &amp; Quint St\"
+        lat=\"37.7371599\" lon=\"-122.3963699\" stopId=\"15881\"/>\n<stop tag=\"5883\"
+        title=\"Palou Ave &amp; Rankin St\" lat=\"37.73821\" lon=\"-122.39824\" stopId=\"15883\"/>\n<stop
+        tag=\"5867\" title=\"Palou Ave &amp; Industrial St\" lat=\"37.7395299\" lon=\"-122.4005499\"
+        stopId=\"15867\"/>\n<stop tag=\"5096\" title=\"Industrial St &amp; Revere
+        Ave\" lat=\"37.73913\" lon=\"-122.4030499\" stopId=\"15096\"/>\n<stop tag=\"5092\"
+        title=\"Industrial St &amp; Bayshore Blvd\" lat=\"37.7381499\" lon=\"-122.40654\"
+        stopId=\"15092\"/>\n<stop tag=\"4155\" title=\"Cortland Ave &amp; Hilton St\"
+        lat=\"37.7396899\" lon=\"-122.40781\" stopId=\"14155\"/>\n<stop tag=\"4147\"
+        title=\"Cortland Ave &amp; Bradford St\" lat=\"37.7397899\" lon=\"-122.4097499\"
+        stopId=\"14147\"/>\n<stop tag=\"4158\" title=\"Cortland Ave &amp; Prentiss
+        St\" lat=\"37.7397799\" lon=\"-122.41199\" stopId=\"14158\"/>\n<stop tag=\"4153\"
+        title=\"Cortland Ave &amp; Folsom St\" lat=\"37.739\" lon=\"-122.4136599\"
+        stopId=\"14153\"/>\n<stop tag=\"4151\" title=\"Cortland Ave &amp; Ellsworth
+        St\" lat=\"37.7389199\" lon=\"-122.41455\" stopId=\"14151\"/>\n<stop tag=\"4142\"
+        title=\"Cortland Ave &amp; Andover St\" lat=\"37.7390899\" lon=\"-122.4163899\"
+        stopId=\"14142\"/>\n<stop tag=\"4145\" title=\"Cortland Ave &amp; Bocana St\"
+        lat=\"37.7393\" lon=\"-122.41846\" stopId=\"14145\"/>\n<stop tag=\"4149\"
+        title=\"Cortland Ave &amp; Elsie St\" lat=\"37.73992\" lon=\"-122.41997\"
+        stopId=\"14149\"/>\n<stop tag=\"4160\" title=\"Cortland Ave &amp; Prospect
+        Ave\" lat=\"37.74029\" lon=\"-122.4209\" stopId=\"14160\"/>\n<stop tag=\"4156\"
+        title=\"Cortland Ave &amp; Mission St\" lat=\"37.7410099\" lon=\"-122.4226699\"
+        stopId=\"14156\"/>\n<stop tag=\"3540\" title=\"30th St &amp; Mission St\"
+        lat=\"37.7424399\" lon=\"-122.42206\" stopId=\"13540\"/>\n<stop tag=\"3537\"
+        title=\"30th St &amp; Dolores St\" lat=\"37.7423\" lon=\"-122.4240299\" stopId=\"13537\"/>\n<stop
+        tag=\"3535\" title=\"30th St &amp; Church St\" lat=\"37.74216\" lon=\"-122.4263699\"
+        stopId=\"13535\"/>\n<stop tag=\"3543\" title=\"30th St &amp; Sanchez St\"
+        lat=\"37.7420199\" lon=\"-122.4286\" stopId=\"13543\"/>\n<stop tag=\"3542\"
+        title=\"30th St &amp; Noe St\" lat=\"37.7418799\" lon=\"-122.43079\" stopId=\"13542\"/>\n<stop
+        tag=\"5737\" title=\"Noe St &amp; 29th St\" lat=\"37.7433\" lon=\"-122.43104\"
+        stopId=\"15737\"/>\n<stop tag=\"5735\" title=\"Noe St &amp; 28th St\" lat=\"37.7449299\"
+        lon=\"-122.4311699\" stopId=\"15735\"/>\n<stop tag=\"5733\" title=\"Noe St
+        &amp; 27th St\" lat=\"37.7465399\" lon=\"-122.4313199\" stopId=\"15733\"/>\n<stop
+        tag=\"3520\" title=\"26th St &amp; Noe St\" lat=\"37.7482699\" lon=\"-122.43177\"
+        stopId=\"13520\"/>\n<stop tag=\"3514\" title=\"26th St &amp; Castro St\" lat=\"37.74815\"
+        lon=\"-122.4336299\" stopId=\"13514\"/>\n<stop tag=\"4329\" title=\"Castro
+        St &amp; 25th St\" lat=\"37.7495999\" lon=\"-122.4338299\" stopId=\"14329\"/>\n<stop
+        tag=\"4326\" title=\"Castro St &amp; 24th St\" lat=\"37.7511999\" lon=\"-122.43401\"
+        stopId=\"14326\"/>\n<stop tag=\"4332\" title=\"Castro St &amp; Elizabeth St\"
+        lat=\"37.75189\" lon=\"-122.43405\" stopId=\"14332\"/>\n<stop tag=\"4324\"
+        title=\"Castro St &amp; 23rd St\" lat=\"37.75278\" lon=\"-122.43416\" stopId=\"14324\"/>\n<stop
+        tag=\"4323\" title=\"Castro St &amp; 22nd St\" lat=\"37.75441\" lon=\"-122.43431\"
+        stopId=\"14323\"/>\n<stop tag=\"4320\" title=\"Castro St &amp; 21st St\" lat=\"37.7559599\"
+        lon=\"-122.4344599\" stopId=\"14320\"/>\n<stop tag=\"4319\" title=\"Castro
+        St &amp; 20th St\" lat=\"37.7576299\" lon=\"-122.4346399\" stopId=\"14319\"/>\n<stop
+        tag=\"4317\" title=\"Castro St &amp; 19th St\" lat=\"37.7591599\" lon=\"-122.4347899\"
+        stopId=\"14317\"/>\n<stop tag=\"34435\" title=\"Divisadero St &amp; Sutter
+        St\" lat=\"37.7851499\" lon=\"-122.43994\" stopId=\"134435\"/>\n<stop tag=\"14148\"
+        title=\"Cortland Ave &amp; Bayshore Blvd\" lat=\"37.7395399\" lon=\"-122.4072\"
+        stopId=\"114148\"/>\n<direction tag=\"24_OB3\" title=\"Outbound to the Bayview
+        District\" name=\"Outbound\" useForUI=\"true\">\n  <stop tag=\"5167\" />\n
+        \ <stop tag=\"5147\" />\n  <stop tag=\"5162\" />\n  <stop tag=\"5160\" />\n
+        \ <stop tag=\"5145\" />\n  <stop tag=\"4413\" />\n  <stop tag=\"4410\" />\n
+        \ <stop tag=\"4433\" />\n  <stop tag=\"4435\" />\n  <stop tag=\"4422\" />\n
+        \ <stop tag=\"4415\" />\n  <stop tag=\"4429\" />\n  <stop tag=\"4426\" />\n
+        \ <stop tag=\"4432\" />\n  <stop tag=\"4424\" />\n  <stop tag=\"4330\" />\n
+        \ <stop tag=\"4308\" />\n  <stop tag=\"4309\" />\n  <stop tag=\"4312\" />\n
+        \ <stop tag=\"4334\" />\n  <stop tag=\"4315\" />\n  <stop tag=\"4316\" />\n
+        \ <stop tag=\"4318\" />\n  <stop tag=\"4321\" />\n  <stop tag=\"4322\" />\n
+        \ <stop tag=\"4325\" />\n  <stop tag=\"4333\" />\n  <stop tag=\"4327\" />\n
+        \ <stop tag=\"4328\" />\n  <stop tag=\"7290\" />\n  <stop tag=\"3521\" />\n
+        \ <stop tag=\"5732\" />\n  <stop tag=\"5734\" />\n  <stop tag=\"5736\" />\n
+        \ <stop tag=\"5738\" />\n  <stop tag=\"3544\" />\n  <stop tag=\"3536\" />\n
+        \ <stop tag=\"3538\" />\n  <stop tag=\"3541\" />\n  <stop tag=\"4157\" />\n
+        \ <stop tag=\"4161\" />\n  <stop tag=\"4150\" />\n  <stop tag=\"4146\" />\n
+        \ <stop tag=\"4143\" />\n  <stop tag=\"4152\" />\n  <stop tag=\"4154\" />\n
+        \ <stop tag=\"4159\" />\n  <stop tag=\"7213\" />\n  <stop tag=\"4148\" />\n
+        \ <stop tag=\"5093\" />\n  <stop tag=\"5094\" />\n  <stop tag=\"5095\" />\n
+        \ <stop tag=\"5884\" />\n  <stop tag=\"5882\" />\n  <stop tag=\"5880\" />\n
+        \ <stop tag=\"5878\" />\n  <stop tag=\"33141\" />\n</direction>\n<direction
+        tag=\"24_IB1\" title=\"Inbound to Pacific Heights\" name=\"Inbound\" useForUI=\"true\">\n
+        \ <stop tag=\"3141\" />\n  <stop tag=\"5490\" />\n  <stop tag=\"5491\" />\n
+        \ <stop tag=\"5492\" />\n  <stop tag=\"5879\" />\n  <stop tag=\"5881\" />\n
+        \ <stop tag=\"5883\" />\n  <stop tag=\"5867\" />\n  <stop tag=\"5096\" />\n
+        \ <stop tag=\"5092\" />\n  <stop tag=\"4155\" />\n  <stop tag=\"4147\" />\n
+        \ <stop tag=\"4158\" />\n  <stop tag=\"4153\" />\n  <stop tag=\"4151\" />\n
+        \ <stop tag=\"4142\" />\n  <stop tag=\"4145\" />\n  <stop tag=\"4149\" />\n
+        \ <stop tag=\"4160\" />\n  <stop tag=\"4156\" />\n  <stop tag=\"3540\" />\n
+        \ <stop tag=\"3537\" />\n  <stop tag=\"3535\" />\n  <stop tag=\"3543\" />\n
+        \ <stop tag=\"3542\" />\n  <stop tag=\"5737\" />\n  <stop tag=\"5735\" />\n
+        \ <stop tag=\"5733\" />\n  <stop tag=\"3520\" />\n  <stop tag=\"3514\" />\n
+        \ <stop tag=\"4329\" />\n  <stop tag=\"4326\" />\n  <stop tag=\"4332\" />\n
+        \ <stop tag=\"4324\" />\n  <stop tag=\"4323\" />\n  <stop tag=\"4320\" />\n
+        \ <stop tag=\"4319\" />\n  <stop tag=\"4317\" />\n  <stop tag=\"4314\" />\n
+        \ <stop tag=\"4313\" />\n  <stop tag=\"4311\" />\n  <stop tag=\"4310\" />\n
+        \ <stop tag=\"4307\" />\n  <stop tag=\"4331\" />\n  <stop tag=\"4423\" />\n
+        \ <stop tag=\"4431\" />\n  <stop tag=\"4425\" />\n  <stop tag=\"4428\" />\n
+        \ <stop tag=\"4414\" />\n  <stop tag=\"4421\" />\n  <stop tag=\"4434\" />\n
+        \ <stop tag=\"4408\" />\n  <stop tag=\"4409\" />\n  <stop tag=\"4412\" />\n
+        \ <stop tag=\"4427\" />\n  <stop tag=\"5161\" />\n  <stop tag=\"5163\" />\n
+        \ <stop tag=\"4624\" />\n  <stop tag=\"6931\" />\n  <stop tag=\"35167\" />\n</direction>\n<path>\n<point
+        lat=\"37.7805\" lon=\"-122.43881\"/>\n<point lat=\"37.78515\" lon=\"-122.43994\"/>\n</path>\n<path>\n<point
+        lat=\"37.77105\" lon=\"-122.4371\"/>\n<point lat=\"37.77034\" lon=\"-122.43686\"/>\n<point
+        lat=\"37.76996\" lon=\"-122.43632\"/>\n<point lat=\"37.76975\" lon=\"-122.4362\"/>\n<point
+        lat=\"37.76938\" lon=\"-122.43592\"/>\n<point lat=\"37.76918\" lon=\"-122.43596\"/>\n<point
+        lat=\"37.76906\" lon=\"-122.4358\"/>\n<point lat=\"37.76742\" lon=\"-122.43571\"/>\n<point
+        lat=\"37.76583\" lon=\"-122.43557\"/>\n<point lat=\"37.76427\" lon=\"-122.43544\"/>\n<point
+        lat=\"37.76214\" lon=\"-122.43519\"/>\n<point lat=\"37.76075\" lon=\"-122.43507\"/>\n</path>\n<path>\n<point
+        lat=\"37.74231\" lon=\"-122.42217\"/>\n<point lat=\"37.74103\" lon=\"-122.42285\"/>\n<point
+        lat=\"37.74085\" lon=\"-122.42251\"/>\n<point lat=\"37.7402\" lon=\"-122.42093\"/>\n<point
+        lat=\"37.7397\" lon=\"-122.41969\"/>\n<point lat=\"37.73931\" lon=\"-122.41872\"/>\n<point
+        lat=\"37.7393\" lon=\"-122.41859\"/>\n<point lat=\"37.73904\" lon=\"-122.41658\"/>\n<point
+        lat=\"37.73888\" lon=\"-122.41467\"/>\n<point lat=\"37.73883\" lon=\"-122.41461\"/>\n<point
+        lat=\"37.73892\" lon=\"-122.41343\"/>\n<point lat=\"37.73897\" lon=\"-122.41341\"/>\n<point
+        lat=\"37.73931\" lon=\"-122.41267\"/>\n<point lat=\"37.73957\" lon=\"-122.41211\"/>\n<point
+        lat=\"37.7398499\" lon=\"-122.41175\"/>\n<point lat=\"37.73971\" lon=\"-122.41017\"/>\n<point
+        lat=\"37.73954\" lon=\"-122.4072\"/>\n</path>\n<path>\n<point lat=\"37.73954\"
+        lon=\"-122.4072\"/>\n<point lat=\"37.73907\" lon=\"-122.40712\"/>\n<point
+        lat=\"37.7388199\" lon=\"-122.40726\"/>\n<point lat=\"37.73888\" lon=\"-122.40755\"/>\n<point
+        lat=\"37.73934\" lon=\"-122.40766\"/>\n<point lat=\"37.73961\" lon=\"-122.40765\"/>\n<point
+        lat=\"37.73969\" lon=\"-122.40781\"/>\n</path>\n<path>\n<point lat=\"37.7805\"
+        lon=\"-122.43881\"/>\n<point lat=\"37.78338\" lon=\"-122.43941\"/>\n<point
+        lat=\"37.78534\" lon=\"-122.43981\"/>\n</path>\n<path>\n<point lat=\"37.73969\"
+        lon=\"-122.40781\"/>\n<point lat=\"37.73979\" lon=\"-122.40975\"/>\n<point
+        lat=\"37.7398499\" lon=\"-122.41175\"/>\n<point lat=\"37.73978\" lon=\"-122.41199\"/>\n<point
+        lat=\"37.739\" lon=\"-122.41319\"/>\n<point lat=\"37.739\" lon=\"-122.41366\"/>\n<point
+        lat=\"37.73892\" lon=\"-122.41455\"/>\n<point lat=\"37.73888\" lon=\"-122.41457\"/>\n<point
+        lat=\"37.73909\" lon=\"-122.41639\"/>\n<point lat=\"37.73925\" lon=\"-122.41846\"/>\n<point
+        lat=\"37.7393\" lon=\"-122.41846\"/>\n<point lat=\"37.73992\" lon=\"-122.41997\"/>\n<point
+        lat=\"37.74029\" lon=\"-122.4209\"/>\n<point lat=\"37.74101\" lon=\"-122.42267\"/>\n<point
+        lat=\"37.74103\" lon=\"-122.42285\"/>\n<point lat=\"37.74244\" lon=\"-122.42206\"/>\n</path>\n<path>\n<point
+        lat=\"37.74244\" lon=\"-122.42206\"/>\n<point lat=\"37.7423\" lon=\"-122.42329\"/>\n<point
+        lat=\"37.7423\" lon=\"-122.42403\"/>\n<point lat=\"37.74216\" lon=\"-122.42637\"/>\n<point
+        lat=\"37.7420199\" lon=\"-122.4286\"/>\n<point lat=\"37.74188\" lon=\"-122.43079\"/>\n<point
+        lat=\"37.74184\" lon=\"-122.43089\"/>\n<point lat=\"37.7433\" lon=\"-122.43104\"/>\n<point
+        lat=\"37.7449299\" lon=\"-122.43117\"/>\n<point lat=\"37.74654\" lon=\"-122.43132\"/>\n<point
+        lat=\"37.74814\" lon=\"-122.43154\"/>\n<point lat=\"37.74827\" lon=\"-122.43177\"/>\n<point
+        lat=\"37.74815\" lon=\"-122.43363\"/>\n<point lat=\"37.7481\" lon=\"-122.43378\"/>\n<point
+        lat=\"37.7496\" lon=\"-122.43383\"/>\n<point lat=\"37.7512\" lon=\"-122.43401\"/>\n</path>\n<path>\n<point
+        lat=\"37.76075\" lon=\"-122.43507\"/>\n<point lat=\"37.75939\" lon=\"-122.43491\"/>\n<point
+        lat=\"37.7577799\" lon=\"-122.43477\"/>\n<point lat=\"37.7561\" lon=\"-122.43462\"/>\n<point
+        lat=\"37.75464\" lon=\"-122.43448\"/>\n<point lat=\"37.7528999\" lon=\"-122.43432\"/>\n<point
+        lat=\"37.75208\" lon=\"-122.43425\"/>\n<point lat=\"37.75125\" lon=\"-122.43418\"/>\n</path>\n<path>\n<point
+        lat=\"37.73409\" lon=\"-122.39093\"/>\n<point lat=\"37.73559\" lon=\"-122.39042\"/>\n<point
+        lat=\"37.7363\" lon=\"-122.39152\"/>\n<point lat=\"37.7363\" lon=\"-122.39165\"/>\n<point
+        lat=\"37.7358\" lon=\"-122.39217\"/>\n<point lat=\"37.7351699\" lon=\"-122.39274\"/>\n<point
+        lat=\"37.73504\" lon=\"-122.39278\"/>\n<point lat=\"37.7361\" lon=\"-122.39453\"/>\n<point
+        lat=\"37.73716\" lon=\"-122.39637\"/>\n<point lat=\"37.73821\" lon=\"-122.39824\"/>\n<point
+        lat=\"37.73953\" lon=\"-122.40055\"/>\n<point lat=\"37.73966\" lon=\"-122.4009\"/>\n<point
+        lat=\"37.73913\" lon=\"-122.40305\"/>\n<point lat=\"37.73815\" lon=\"-122.40654\"/>\n<point
+        lat=\"37.73797\" lon=\"-122.40692\"/>\n<point lat=\"37.73846\" lon=\"-122.40707\"/>\n<point
+        lat=\"37.73907\" lon=\"-122.40712\"/>\n<point lat=\"37.73932\" lon=\"-122.40708\"/>\n<point
+        lat=\"37.73957\" lon=\"-122.40698\"/>\n<point lat=\"37.73969\" lon=\"-122.40781\"/>\n</path>\n<path>\n<point
+        lat=\"37.77133\" lon=\"-122.43698\"/>\n<point lat=\"37.77319\" lon=\"-122.43735\"/>\n<point
+        lat=\"37.77506\" lon=\"-122.43774\"/>\n<point lat=\"37.7778599\" lon=\"-122.4383\"/>\n<point
+        lat=\"37.7805\" lon=\"-122.43881\"/>\n</path>\n<path>\n<point lat=\"37.78534\"
+        lon=\"-122.43981\"/>\n<point lat=\"37.78628\" lon=\"-122.44\"/>\n<point lat=\"37.7881799\"
+        lon=\"-122.44038\"/>\n<point lat=\"37.78998\" lon=\"-122.44074\"/>\n<point
+        lat=\"37.79154\" lon=\"-122.44108\"/>\n<point lat=\"37.79163\" lon=\"-122.44116\"/>\n<point
+        lat=\"37.79177\" lon=\"-122.43961\"/>\n<point lat=\"37.7922\" lon=\"-122.43632\"/>\n<point
+        lat=\"37.79247\" lon=\"-122.43456\"/>\n<point lat=\"37.79239\" lon=\"-122.43461\"/>\n<point
+        lat=\"37.79158\" lon=\"-122.43439\"/>\n<point lat=\"37.79172\" lon=\"-122.43284\"/>\n<point
+        lat=\"37.7918\" lon=\"-122.43275\"/>\n<point lat=\"37.79267\" lon=\"-122.43292\"/>\n<point
+        lat=\"37.79272\" lon=\"-122.43302\"/>\n</path>\n<path>\n<point lat=\"37.76084\"
+        lon=\"-122.43493\"/>\n<point lat=\"37.76237\" lon=\"-122.43508\"/>\n<point
+        lat=\"37.7641599\" lon=\"-122.43525\"/>\n<point lat=\"37.76561\" lon=\"-122.43538\"/>\n<point
+        lat=\"37.76761\" lon=\"-122.43558\"/>\n<point lat=\"37.7689499\" lon=\"-122.43571\"/>\n<point
+        lat=\"37.76906\" lon=\"-122.4358\"/>\n<point lat=\"37.76938\" lon=\"-122.43592\"/>\n<point
+        lat=\"37.76975\" lon=\"-122.4362\"/>\n<point lat=\"37.76996\" lon=\"-122.43632\"/>\n<point
+        lat=\"37.77029\" lon=\"-122.43678\"/>\n<point lat=\"37.77133\" lon=\"-122.43698\"/>\n</path>\n<path>\n<point
+        lat=\"37.73954\" lon=\"-122.4072\"/>\n<point lat=\"37.73957\" lon=\"-122.40698\"/>\n<point
+        lat=\"37.73932\" lon=\"-122.40708\"/>\n<point lat=\"37.73907\" lon=\"-122.40712\"/>\n<point
+        lat=\"37.7381\" lon=\"-122.40701\"/>\n<point lat=\"37.73794\" lon=\"-122.40678\"/>\n<point
+        lat=\"37.73833\" lon=\"-122.40566\"/>\n<point lat=\"37.73879\" lon=\"-122.40373\"/>\n<point
+        lat=\"37.73955\" lon=\"-122.40101\"/>\n<point lat=\"37.73966\" lon=\"-122.4009\"/>\n<point
+        lat=\"37.73825\" lon=\"-122.39853\"/>\n<point lat=\"37.73722\" lon=\"-122.39672\"/>\n<point
+        lat=\"37.7361\" lon=\"-122.39481\"/>\n<point lat=\"37.73503\" lon=\"-122.39266\"/>\n<point
+        lat=\"37.73409\" lon=\"-122.39093\"/>\n</path>\n<path>\n<point lat=\"37.78045\"
+        lon=\"-122.43898\"/>\n<point lat=\"37.7776799\" lon=\"-122.43841\"/>\n<point
+        lat=\"37.77489\" lon=\"-122.43786\"/>\n<point lat=\"37.77305\" lon=\"-122.43749\"/>\n<point
+        lat=\"37.77105\" lon=\"-122.4371\"/>\n</path>\n<path>\n<point lat=\"37.78515\"
+        lon=\"-122.43994\"/>\n<point lat=\"37.78316\" lon=\"-122.43953\"/>\n<point
+        lat=\"37.78045\" lon=\"-122.43898\"/>\n</path>\n<path>\n<point lat=\"37.75125\"
+        lon=\"-122.43418\"/>\n<point lat=\"37.7498099\" lon=\"-122.43404\"/>\n<point
+        lat=\"37.7482\" lon=\"-122.43389\"/>\n<point lat=\"37.7481\" lon=\"-122.43378\"/>\n<point
+        lat=\"37.74817\" lon=\"-122.43164\"/>\n<point lat=\"37.74823\" lon=\"-122.43157\"/>\n<point
+        lat=\"37.74668\" lon=\"-122.43148\"/>\n<point lat=\"37.74519\" lon=\"-122.43134\"/>\n<point
+        lat=\"37.74354\" lon=\"-122.43117\"/>\n<point lat=\"37.74201\" lon=\"-122.43101\"/>\n<point
+        lat=\"37.74192\" lon=\"-122.43096\"/>\n<point lat=\"37.74189\" lon=\"-122.42995\"/>\n<point
+        lat=\"37.74191\" lon=\"-122.42902\"/>\n<point lat=\"37.74204\" lon=\"-122.42676\"/>\n<point
+        lat=\"37.74217\" lon=\"-122.42446\"/>\n<point lat=\"37.74231\" lon=\"-122.42217\"/>\n</path>\n<path>\n<point
+        lat=\"37.73969\" lon=\"-122.40781\"/>\n<point lat=\"37.73979\" lon=\"-122.40975\"/>\n<point
+        lat=\"37.7398499\" lon=\"-122.41175\"/>\n<point lat=\"37.73978\" lon=\"-122.41199\"/>\n<point
+        lat=\"37.739\" lon=\"-122.41319\"/>\n<point lat=\"37.739\" lon=\"-122.41366\"/>\n<point
+        lat=\"37.73892\" lon=\"-122.41455\"/>\n<point lat=\"37.73888\" lon=\"-122.41457\"/>\n<point
+        lat=\"37.73909\" lon=\"-122.41639\"/>\n<point lat=\"37.73925\" lon=\"-122.41846\"/>\n<point
+        lat=\"37.7393\" lon=\"-122.41846\"/>\n<point lat=\"37.73992\" lon=\"-122.41997\"/>\n<point
+        lat=\"37.74029\" lon=\"-122.4209\"/>\n<point lat=\"37.74101\" lon=\"-122.42267\"/>\n<point
+        lat=\"37.74103\" lon=\"-122.42285\"/>\n<point lat=\"37.7421999\" lon=\"-122.42209\"/>\n<point
+        lat=\"37.74244\" lon=\"-122.42206\"/>\n</path>\n<path>\n<point lat=\"37.7512\"
+        lon=\"-122.43401\"/>\n<point lat=\"37.75189\" lon=\"-122.43405\"/>\n<point
+        lat=\"37.75278\" lon=\"-122.43416\"/>\n<point lat=\"37.75441\" lon=\"-122.43431\"/>\n<point
+        lat=\"37.75596\" lon=\"-122.43446\"/>\n<point lat=\"37.75763\" lon=\"-122.43464\"/>\n<point
+        lat=\"37.75916\" lon=\"-122.43479\"/>\n<point lat=\"37.76084\" lon=\"-122.43493\"/>\n</path>\n<path>\n<point
+        lat=\"37.73409\" lon=\"-122.39093\"/>\n<point lat=\"37.73559\" lon=\"-122.39042\"/>\n<point
+        lat=\"37.7363\" lon=\"-122.39152\"/>\n<point lat=\"37.7363\" lon=\"-122.39165\"/>\n<point
+        lat=\"37.7358\" lon=\"-122.39217\"/>\n<point lat=\"37.7351699\" lon=\"-122.39274\"/>\n<point
+        lat=\"37.73504\" lon=\"-122.39278\"/>\n<point lat=\"37.73566\" lon=\"-122.39222\"/>\n<point
+        lat=\"37.73504\" lon=\"-122.39278\"/>\n<point lat=\"37.7361\" lon=\"-122.39453\"/>\n<point
+        lat=\"37.73716\" lon=\"-122.39637\"/>\n<point lat=\"37.73821\" lon=\"-122.39824\"/>\n<point
+        lat=\"37.73953\" lon=\"-122.40055\"/>\n<point lat=\"37.73966\" lon=\"-122.4009\"/>\n<point
+        lat=\"37.73913\" lon=\"-122.40305\"/>\n<point lat=\"37.73815\" lon=\"-122.40654\"/>\n<point
+        lat=\"37.73797\" lon=\"-122.40692\"/>\n<point lat=\"37.73846\" lon=\"-122.40707\"/>\n<point
+        lat=\"37.73907\" lon=\"-122.40712\"/>\n<point lat=\"37.73932\" lon=\"-122.40708\"/>\n<point
+        lat=\"37.73957\" lon=\"-122.40698\"/>\n<point lat=\"37.73969\" lon=\"-122.40781\"/>\n</path>\n<path>\n<point
+        lat=\"37.7805\" lon=\"-122.43881\"/>\n<point lat=\"37.78534\" lon=\"-122.43981\"/>\n</path>\n<path>\n<point
+        lat=\"37.74231\" lon=\"-122.42217\"/>\n<point lat=\"37.74238\" lon=\"-122.42198\"/>\n<point
+        lat=\"37.74103\" lon=\"-122.42285\"/>\n<point lat=\"37.74085\" lon=\"-122.42251\"/>\n<point
+        lat=\"37.7402\" lon=\"-122.42093\"/>\n<point lat=\"37.7397\" lon=\"-122.41969\"/>\n<point
+        lat=\"37.73931\" lon=\"-122.41872\"/>\n<point lat=\"37.7393\" lon=\"-122.41859\"/>\n<point
+        lat=\"37.73904\" lon=\"-122.41658\"/>\n<point lat=\"37.73888\" lon=\"-122.41467\"/>\n<point
+        lat=\"37.73883\" lon=\"-122.41461\"/>\n<point lat=\"37.73892\" lon=\"-122.41343\"/>\n<point
+        lat=\"37.73897\" lon=\"-122.41341\"/>\n<point lat=\"37.73931\" lon=\"-122.41267\"/>\n<point
+        lat=\"37.73957\" lon=\"-122.41211\"/>\n<point lat=\"37.7398499\" lon=\"-122.41175\"/>\n<point
+        lat=\"37.73971\" lon=\"-122.41017\"/>\n<point lat=\"37.73954\" lon=\"-122.4072\"/>\n</path>\n<path>\n<point
+        lat=\"37.79272\" lon=\"-122.43302\"/>\n<point lat=\"37.79253\" lon=\"-122.43468\"/>\n<point
+        lat=\"37.79235\" lon=\"-122.43611\"/>\n<point lat=\"37.79193\" lon=\"-122.43924\"/>\n<point
+        lat=\"37.79172\" lon=\"-122.44089\"/>\n<point lat=\"37.79163\" lon=\"-122.44116\"/>\n<point
+        lat=\"37.7899699\" lon=\"-122.44089\"/>\n<point lat=\"37.78799\" lon=\"-122.4405\"/>\n<point
+        lat=\"37.787\" lon=\"-122.44032\"/>\n<point lat=\"37.78515\" lon=\"-122.43994\"/>\n</path>\n<path>\n<point
+        lat=\"37.78534\" lon=\"-122.43981\"/>\n<point lat=\"37.78628\" lon=\"-122.44\"/>\n<point
+        lat=\"37.7881799\" lon=\"-122.44038\"/>\n<point lat=\"37.78998\" lon=\"-122.44074\"/>\n<point
+        lat=\"37.79154\" lon=\"-122.44108\"/>\n<point lat=\"37.79163\" lon=\"-122.44116\"/>\n<point
+        lat=\"37.79177\" lon=\"-122.43961\"/>\n<point lat=\"37.7922\" lon=\"-122.43632\"/>\n</path>\n</route>\n</body>\n"
+    http_version: 
+  recorded_at: Tue, 26 Mar 2013 19:47:57 GMT
+recorded_with: VCR 2.4.0

--- a/spec/cassettes/Muni_Route/fetches_all_available_routes.yml
+++ b/spec/cassettes/Muni_Route/fetches_all_available_routes.yml
@@ -1,0 +1,87 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://webservices.nextbus.com/service/publicXMLFeed?a=sf-muni&command=routeList
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - '*/*'
+      User-Agent:
+      - Ruby
+      Host:
+      - webservices.nextbus.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 Mar 2013 19:41:23 GMT
+      Server:
+      - Apache/2.2.4 (Unix) mod_ssl/2.2.4 OpenSSL/0.9.7m DAV/2 mod_jk/1.2.30
+      Access-Control-Allow-Origin:
+      - '*'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1030'
+      Content-Type:
+      - text/xml
+      X-Pad:
+      - avoid browser bug
+    body:
+      encoding: UTF-8
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\" ?> \n<body copyright=\"All
+        data copyright San Francisco Muni 2013.\">\n<route tag=\"F\" title=\"F-Market
+        &amp; Wharves\"/>\n<route tag=\"J\" title=\"J-Church\"/>\n<route tag=\"KT\"
+        title=\"KT-Ingleside/Third Street\"/>\n<route tag=\"L\" title=\"L-Taraval\"/>\n<route
+        tag=\"M\" title=\"M-Ocean View\"/>\n<route tag=\"N\" title=\"N-Judah\"/>\n<route
+        tag=\"NX\" title=\"NX-N Express\"/>\n<route tag=\"1\" title=\"1-California\"/>\n<route
+        tag=\"1AX\" title=\"1AX-California A Express\"/>\n<route tag=\"1BX\" title=\"1BX-California
+        B Express\"/>\n<route tag=\"2\" title=\"2-Clement\"/>\n<route tag=\"3\" title=\"3-Jackson\"/>\n<route
+        tag=\"5\" title=\"5-Fulton\"/>\n<route tag=\"6\" title=\"6-Parnassus\"/>\n<route
+        tag=\"8X\" title=\"8X-Bayshore Exp\"/>\n<route tag=\"8AX\" title=\"8AX-Bayshore
+        A Exp\"/>\n<route tag=\"8BX\" title=\"8BX-Bayshore B Exp\"/>\n<route tag=\"9\"
+        title=\"9-San Bruno\"/>\n<route tag=\"9L\" title=\"9L-San Bruno Limited\"/>\n<route
+        tag=\"10\" title=\"10-Townsend\"/>\n<route tag=\"12\" title=\"12-Folsom/Pacific\"/>\n<route
+        tag=\"14\" title=\"14-Mission\"/>\n<route tag=\"14L\" title=\"14L-Mission
+        Limited\"/>\n<route tag=\"14X\" title=\"14X-Mission Express\"/>\n<route tag=\"16X\"
+        title=\"16X-Noriega Express\"/>\n<route tag=\"17\" title=\"17-Park Merced\"/>\n<route
+        tag=\"18\" title=\"18-46th Avenue\"/>\n<route tag=\"19\" title=\"19-Polk\"/>\n<route
+        tag=\"21\" title=\"21-Hayes\"/>\n<route tag=\"22\" title=\"22-Fillmore\"/>\n<route
+        tag=\"23\" title=\"23-Monterey\"/>\n<route tag=\"24\" title=\"24-Divisadero\"/>\n<route
+        tag=\"27\" title=\"27-Bryant\"/>\n<route tag=\"28\" title=\"28-19th Avenue\"/>\n<route
+        tag=\"29\" title=\"29-Sunset\"/>\n<route tag=\"30\" title=\"30-Stockton\"/>\n<route
+        tag=\"30X\" title=\"30X-Marina Express\"/>\n<route tag=\"31\" title=\"31-Balboa\"/>\n<route
+        tag=\"31AX\" title=\"31AX-Balboa A Express\"/>\n<route tag=\"31BX\" title=\"31BX-Balboa
+        B Express\"/>\n<route tag=\"33\" title=\"33-Stanyan\"/>\n<route tag=\"35\"
+        title=\"35-Eureka\"/>\n<route tag=\"36\" title=\"36-Teresita\"/>\n<route tag=\"37\"
+        title=\"37-Corbett\"/>\n<route tag=\"38\" title=\"38-Geary\"/>\n<route tag=\"38AX\"
+        title=\"38AX-Geary A Express\"/>\n<route tag=\"38BX\" title=\"38BX-Geary B
+        Express\"/>\n<route tag=\"38L\" title=\"38L-Geary Limited\"/>\n<route tag=\"39\"
+        title=\"39-Coit\"/>\n<route tag=\"41\" title=\"41-Union\"/>\n<route tag=\"43\"
+        title=\"43-Masonic\"/>\n<route tag=\"44\" title=\"44-O&apos;Shaughnessy\"/>\n<route
+        tag=\"45\" title=\"45-Union/Stockton\"/>\n<route tag=\"47\" title=\"47-Van
+        Ness\"/>\n<route tag=\"48\" title=\"48-Quintara - 24th Street\"/>\n<route
+        tag=\"49\" title=\"49-Mission-Van Ness\"/>\n<route tag=\"52\" title=\"52-Excelsior\"/>\n<route
+        tag=\"54\" title=\"54-Felton\"/>\n<route tag=\"56\" title=\"56-Rutland\"/>\n<route
+        tag=\"66\" title=\"66-Quintara\"/>\n<route tag=\"67\" title=\"67-Bernal Heights\"/>\n<route
+        tag=\"71\" title=\"71-Haight-Noriega\"/>\n<route tag=\"71L\" title=\"71L-Haight-Noriega
+        Limited\"/>\n<route tag=\"76\" title=\"76-Marin Headlands\"/>\n<route tag=\"81X\"
+        title=\"81X-Caltrain Express\"/>\n<route tag=\"82X\" title=\"82X-Levi Plaza
+        Express\"/>\n<route tag=\"83X\" title=\"83X-Caltrain\"/>\n<route tag=\"88\"
+        title=\"88-B.A.R.T. Shuttle\"/>\n<route tag=\"90\" title=\"90-San Bruno Owl\"/>\n<route
+        tag=\"91\" title=\"91-Owl\"/>\n<route tag=\"108\" title=\"108-Treasure Island\"/>\n<route
+        tag=\"K OWL\" title=\"K-Owl\"/>\n<route tag=\"L OWL\" title=\"L-Owl\"/>\n<route
+        tag=\"M OWL\" title=\"M-Owl\"/>\n<route tag=\"N OWL\" title=\"N-Owl\"/>\n<route
+        tag=\"T OWL\" title=\"T-Owl\"/>\n<route tag=\"59\" title=\"Powell/Mason Cable
+        Car\"/>\n<route tag=\"60\" title=\"Powell/Hyde Cable Car\"/>\n<route tag=\"61\"
+        title=\"California Cable Car\"/>\n</body>\n"
+    http_version: 
+  recorded_at: Tue, 26 Mar 2013 19:41:23 GMT
+recorded_with: VCR 2.4.0

--- a/spec/cassettes/Muni_Route/fetches_routes_by_tag.yml
+++ b/spec/cassettes/Muni_Route/fetches_routes_by_tag.yml
@@ -1,0 +1,204 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://webservices.nextbus.com/service/publicXMLFeed?a=sf-muni&command=routeConfig&r=21
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - '*/*'
+      User-Agent:
+      - Ruby
+      Host:
+      - webservices.nextbus.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 Mar 2013 19:41:23 GMT
+      Server:
+      - Apache/2.2.4 (Unix) mod_ssl/2.2.4 OpenSSL/0.9.7m DAV/2 mod_jk/1.2.30
+      Access-Control-Allow-Origin:
+      - '*'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2235'
+      Content-Type:
+      - text/xml
+      X-Pad:
+      - avoid browser bug
+    body:
+      encoding: UTF-8
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\" ?> \n<body copyright=\"All
+        data copyright San Francisco Muni 2013.\">\n<route tag=\"21\" title=\"21-Hayes\"
+        color=\"660000\" oppositeColor=\"ffffff\" latMin=\"37.7729599\" latMax=\"37.7944299\"
+        lonMin=\"-122.46384\" lonMax=\"-122.39323\">\n<stop tag=\"6497\" title=\"Steuart
+        St &amp; Mission St\" lat=\"37.7933499\" lon=\"-122.39323\" stopId=\"16497\"/>\n<stop
+        tag=\"6501\" title=\"Steuart St &amp; Market St\" lat=\"37.7944299\" lon=\"-122.3945499\"
+        stopId=\"16501\"/>\n<stop tag=\"5669\" title=\"Market St &amp; Drumm St\"
+        lat=\"37.79347\" lon=\"-122.3961799\" stopId=\"15669\"/>\n<stop tag=\"5671\"
+        title=\"Market St &amp; Front St\" lat=\"37.79192\" lon=\"-122.3981499\" stopId=\"15671\"/>\n<stop
+        tag=\"5689\" title=\"Market St &amp; Sansome St\" lat=\"37.7901599\" lon=\"-122.40041\"
+        stopId=\"15689\"/>\n<stop tag=\"5684\" title=\"Market St &amp; Montgomery
+        St\" lat=\"37.7884899\" lon=\"-122.40248\" stopId=\"15684\"/>\n<stop tag=\"5674\"
+        title=\"Market St &amp; Grant Ave\" lat=\"37.78639\" lon=\"-122.4051599\"
+        stopId=\"15674\"/>\n<stop tag=\"5688\" title=\"Market St &amp; Powell St\"
+        lat=\"37.7846799\" lon=\"-122.40731\" stopId=\"15688\"/>\n<stop tag=\"5683\"
+        title=\"Market St &amp; Mason St\" lat=\"37.7828499\" lon=\"-122.40964\" stopId=\"15683\"/>\n<stop
+        tag=\"5656\" title=\"Market St &amp; 7th St North\" lat=\"37.7805699\" lon=\"-122.41244\"
+        stopId=\"15656\"/>\n<stop tag=\"7423\" title=\"Market St &amp; Hyde St\" lat=\"37.7787799\"
+        lon=\"-122.41472\" stopId=\"17423\"/>\n<stop tag=\"4997\" title=\"Hayes St
+        &amp; Larkin St\" lat=\"37.7777099\" lon=\"-122.41685\" stopId=\"14997\"/>\n<stop
+        tag=\"5013\" title=\"Hayes St &amp; Van Ness Ave\" lat=\"37.7772899\" lon=\"-122.42019\"
+        stopId=\"15013\"/>\n<stop tag=\"4996\" title=\"Hayes St &amp; Gough St\" lat=\"37.77689\"
+        lon=\"-122.4233299\" stopId=\"14996\"/>\n<stop tag=\"4998\" title=\"Hayes
+        St &amp; Laguna St\" lat=\"37.7765299\" lon=\"-122.42615\" stopId=\"14998\"/>\n<stop
+        tag=\"4983\" title=\"Hayes St &amp; Buchanan St\" lat=\"37.7762599\" lon=\"-122.42827\"
+        stopId=\"14983\"/>\n<stop tag=\"5014\" title=\"Hayes St &amp; Webster St\"
+        lat=\"37.7760599\" lon=\"-122.42988\" stopId=\"15014\"/>\n<stop tag=\"4993\"
+        title=\"Hayes St &amp; Fillmore St\" lat=\"37.77584\" lon=\"-122.4315599\"
+        stopId=\"14993\"/>\n<stop tag=\"5011\" title=\"Hayes St &amp; Steiner St\"
+        lat=\"37.77563\" lon=\"-122.4331999\" stopId=\"15011\"/>\n<stop tag=\"5003\"
+        title=\"Hayes St &amp; Pierce St\" lat=\"37.77547\" lon=\"-122.4344399\" stopId=\"15003\"/>\n<stop
+        tag=\"4991\" title=\"Hayes St &amp; Divisadero St\" lat=\"37.7749899\" lon=\"-122.43818\"
+        stopId=\"14991\"/>\n<stop tag=\"4979\" title=\"Hayes St &amp; Baker St\" lat=\"37.7745699\"
+        lon=\"-122.4415\" stopId=\"14979\"/>\n<stop tag=\"4999\" title=\"Hayes St
+        &amp; Lyon St\" lat=\"37.77443\" lon=\"-122.4426299\" stopId=\"14999\"/>\n<stop
+        tag=\"4985\" title=\"Hayes St &amp; Central Ave\" lat=\"37.7742\" lon=\"-122.4442999\"
+        stopId=\"14985\"/>\n<stop tag=\"5001\" title=\"Hayes St &amp; Masonic Ave\"
+        lat=\"37.7739299\" lon=\"-122.44651\" stopId=\"15001\"/>\n<stop tag=\"4987\"
+        title=\"Hayes St &amp; Clayton St\" lat=\"37.7736099\" lon=\"-122.44917\"
+        stopId=\"14987\"/>\n<stop tag=\"5007\" title=\"Hayes St &amp; Shrader St\"
+        lat=\"37.7731699\" lon=\"-122.4525\" stopId=\"15007\"/>\n<stop tag=\"5009\"
+        title=\"Hayes St &amp; Stanyan St\" lat=\"37.7729599\" lon=\"-122.45415\"
+        stopId=\"15009\"/>\n<stop tag=\"37499\" title=\"Fulton St &amp; Shrader St\"
+        lat=\"37.7748699\" lon=\"-122.45309\" stopId=\"137499\"/>\n<stop tag=\"7499\"
+        title=\"Fulton St &amp; Shrader St\" lat=\"37.7748699\" lon=\"-122.45309\"
+        stopId=\"17499\"/>\n<stop tag=\"7561\" title=\"Hayes St &amp; Shrader St\"
+        lat=\"37.77306\" lon=\"-122.4525099\" stopId=\"17561\"/>\n<stop tag=\"4988\"
+        title=\"Hayes St &amp; Clayton St\" lat=\"37.7734199\" lon=\"-122.44946\"
+        stopId=\"14988\"/>\n<stop tag=\"5002\" title=\"Hayes St &amp; Masonic Ave\"
+        lat=\"37.7739499\" lon=\"-122.44568\" stopId=\"15002\"/>\n<stop tag=\"4986\"
+        title=\"Hayes St &amp; Central Ave\" lat=\"37.77409\" lon=\"-122.4445099\"
+        stopId=\"14986\"/>\n<stop tag=\"5000\" title=\"Hayes St &amp; Lyon St\" lat=\"37.7742899\"
+        lon=\"-122.44286\" stopId=\"15000\"/>\n<stop tag=\"4980\" title=\"Hayes St
+        &amp; Baker St\" lat=\"37.7745099\" lon=\"-122.44126\" stopId=\"14980\"/>\n<stop
+        tag=\"4992\" title=\"Hayes St &amp; Divisadero St\" lat=\"37.7749999\" lon=\"-122.4374\"
+        stopId=\"14992\"/>\n<stop tag=\"5004\" title=\"Hayes St &amp; Pierce St\"
+        lat=\"37.7754099\" lon=\"-122.43418\" stopId=\"15004\"/>\n<stop tag=\"5012\"
+        title=\"Hayes St &amp; Steiner St\" lat=\"37.77563\" lon=\"-122.4324799\"
+        stopId=\"15012\"/>\n<stop tag=\"4994\" title=\"Hayes St &amp; Fillmore St\"
+        lat=\"37.7757999\" lon=\"-122.43083\" stopId=\"14994\"/>\n<stop tag=\"5015\"
+        title=\"Hayes St &amp; Webster St\" lat=\"37.7760399\" lon=\"-122.42919\"
+        stopId=\"15015\"/>\n<stop tag=\"4984\" title=\"Hayes St &amp; Buchanan St\"
+        lat=\"37.77624\" lon=\"-122.4275499\" stopId=\"14984\"/>\n<stop tag=\"5260\"
+        title=\"Laguna St &amp; Hayes St\" lat=\"37.7767499\" lon=\"-122.42627\" stopId=\"15260\"/>\n<stop
+        tag=\"4921\" title=\"Grove St &amp; Laguna St\" lat=\"37.77738\" lon=\"-122.4263199\"
+        stopId=\"14921\"/>\n<stop tag=\"4920\" title=\"Grove St &amp; Gough St\" lat=\"37.77775\"
+        lon=\"-122.4233099\" stopId=\"14920\"/>\n<stop tag=\"4923\" title=\"Grove
+        St &amp; Van Ness Ave\" lat=\"37.7781899\" lon=\"-122.41974\" stopId=\"14923\"/>\n<stop
+        tag=\"7463\" title=\"Grove St &amp; Polk St\" lat=\"37.77838\" lon=\"-122.4183099\"
+        stopId=\"17463\"/>\n<stop tag=\"5652\" title=\"Market St &amp; 9th St\" lat=\"37.77741\"
+        lon=\"-122.4163399\" stopId=\"15652\"/>\n<stop tag=\"5651\" title=\"Market
+        St &amp; 8th St\" lat=\"37.77861\" lon=\"-122.4148299\" stopId=\"15651\"/>\n<stop
+        tag=\"5650\" title=\"Market St &amp; 7th St\" lat=\"37.7803599\" lon=\"-122.41261\"
+        stopId=\"15650\"/>\n<stop tag=\"5647\" title=\"Market St &amp; 6th St\" lat=\"37.7820999\"
+        lon=\"-122.4104\" stopId=\"15647\"/>\n<stop tag=\"5645\" title=\"Market St
+        &amp; 5th St\" lat=\"37.7838899\" lon=\"-122.40814\" stopId=\"15645\"/>\n<stop
+        tag=\"5643\" title=\"Market St &amp; 4th St\" lat=\"37.7856499\" lon=\"-122.40589\"
+        stopId=\"15643\"/>\n<stop tag=\"5640\" title=\"Market St &amp; 3rd St\" lat=\"37.7875299\"
+        lon=\"-122.40352\" stopId=\"15640\"/>\n<stop tag=\"5685\" title=\"Market St
+        &amp; New Montgomery St\" lat=\"37.7886099\" lon=\"-122.40216\" stopId=\"15685\"/>\n<stop
+        tag=\"7264\" title=\"Market St &amp; 1st St\" lat=\"37.79094\" lon=\"-122.3991899\"
+        stopId=\"17264\"/>\n<stop tag=\"5658\" title=\"Market St &amp; Beale St\"
+        lat=\"37.79257\" lon=\"-122.3970199\" stopId=\"15658\"/>\n<stop tag=\"6475\"
+        title=\"Spear St &amp; Market St\" lat=\"37.7935899\" lon=\"-122.3955499\"
+        stopId=\"16475\"/>\n<stop tag=\"36497\" title=\"Steuart St &amp; Mission St\"
+        lat=\"37.7933499\" lon=\"-122.39323\" stopId=\"136497\"/>\n<stop tag=\"4733\"
+        title=\"Fulton St &amp; 6th Ave\" lat=\"37.7735299\" lon=\"-122.46384\" stopId=\"14733\"/>\n<stop
+        tag=\"3089\" title=\"Beale St &amp; Mission St\" lat=\"37.7917499\" lon=\"-122.3967\"
+        stopId=\"13089\"/>\n<direction tag=\"21_IB1\" title=\"Inbound to Downtown\"
+        name=\"Inbound\" useForUI=\"true\">\n  <stop tag=\"7499\" />\n  <stop tag=\"7561\"
+        />\n  <stop tag=\"4988\" />\n  <stop tag=\"5002\" />\n  <stop tag=\"4986\"
+        />\n  <stop tag=\"5000\" />\n  <stop tag=\"4980\" />\n  <stop tag=\"4992\"
+        />\n  <stop tag=\"5004\" />\n  <stop tag=\"5012\" />\n  <stop tag=\"4994\"
+        />\n  <stop tag=\"5015\" />\n  <stop tag=\"4984\" />\n  <stop tag=\"5260\"
+        />\n  <stop tag=\"4921\" />\n  <stop tag=\"4920\" />\n  <stop tag=\"4923\"
+        />\n  <stop tag=\"7463\" />\n  <stop tag=\"5652\" />\n  <stop tag=\"5651\"
+        />\n  <stop tag=\"5650\" />\n  <stop tag=\"5647\" />\n  <stop tag=\"5645\"
+        />\n  <stop tag=\"5643\" />\n  <stop tag=\"5640\" />\n  <stop tag=\"5685\"
+        />\n  <stop tag=\"7264\" />\n  <stop tag=\"5658\" />\n  <stop tag=\"6475\"
+        />\n  <stop tag=\"36497\" />\n</direction>\n<direction tag=\"21_OB4\" title=\"Outbound
+        to Golden Gate Park\" name=\"Outbound\" useForUI=\"true\">\n  <stop tag=\"6497\"
+        />\n  <stop tag=\"6501\" />\n  <stop tag=\"5669\" />\n  <stop tag=\"5671\"
+        />\n  <stop tag=\"5689\" />\n  <stop tag=\"5684\" />\n  <stop tag=\"5674\"
+        />\n  <stop tag=\"5688\" />\n  <stop tag=\"5683\" />\n  <stop tag=\"5656\"
+        />\n  <stop tag=\"7423\" />\n  <stop tag=\"4997\" />\n  <stop tag=\"5013\"
+        />\n  <stop tag=\"4996\" />\n  <stop tag=\"4998\" />\n  <stop tag=\"4983\"
+        />\n  <stop tag=\"5014\" />\n  <stop tag=\"4993\" />\n  <stop tag=\"5011\"
+        />\n  <stop tag=\"5003\" />\n  <stop tag=\"4991\" />\n  <stop tag=\"4979\"
+        />\n  <stop tag=\"4999\" />\n  <stop tag=\"4985\" />\n  <stop tag=\"5001\"
+        />\n  <stop tag=\"4987\" />\n  <stop tag=\"5007\" />\n  <stop tag=\"5009\"
+        />\n  <stop tag=\"37499\" />\n</direction>\n<path>\n<point lat=\"37.775\"
+        lon=\"-122.4374\"/>\n<point lat=\"37.77541\" lon=\"-122.43418\"/>\n<point
+        lat=\"37.77563\" lon=\"-122.43248\"/>\n<point lat=\"37.7757999\" lon=\"-122.43083\"/>\n<point
+        lat=\"37.77604\" lon=\"-122.42919\"/>\n<point lat=\"37.77624\" lon=\"-122.42755\"/>\n<point
+        lat=\"37.77646\" lon=\"-122.42627\"/>\n<point lat=\"37.77675\" lon=\"-122.42627\"/>\n<point
+        lat=\"37.7773899\" lon=\"-122.42646\"/>\n<point lat=\"37.77738\" lon=\"-122.42632\"/>\n<point
+        lat=\"37.77775\" lon=\"-122.42331\"/>\n<point lat=\"37.77819\" lon=\"-122.41974\"/>\n</path>\n<path>\n<point
+        lat=\"37.77487\" lon=\"-122.45309\"/>\n<point lat=\"37.77496\" lon=\"-122.45299\"/>\n<point
+        lat=\"37.7731\" lon=\"-122.45262\"/>\n<point lat=\"37.77306\" lon=\"-122.45251\"/>\n<point
+        lat=\"37.77342\" lon=\"-122.44946\"/>\n<point lat=\"37.77395\" lon=\"-122.44568\"/>\n</path>\n<path>\n<point
+        lat=\"37.77819\" lon=\"-122.41974\"/>\n<point lat=\"37.77848\" lon=\"-122.41823\"/>\n<point
+        lat=\"37.77838\" lon=\"-122.41831\"/>\n<point lat=\"37.7768\" lon=\"-122.4179\"/>\n<point
+        lat=\"37.77654\" lon=\"-122.41751\"/>\n<point lat=\"37.77741\" lon=\"-122.41634\"/>\n<point
+        lat=\"37.77861\" lon=\"-122.41483\"/>\n<point lat=\"37.78036\" lon=\"-122.41261\"/>\n</path>\n<path>\n<point
+        lat=\"37.7856499\" lon=\"-122.40589\"/>\n<point lat=\"37.7875299\" lon=\"-122.40352\"/>\n<point
+        lat=\"37.78861\" lon=\"-122.40216\"/>\n</path>\n<path>\n<point lat=\"37.77393\"
+        lon=\"-122.44651\"/>\n<point lat=\"37.77361\" lon=\"-122.44917\"/>\n<point
+        lat=\"37.77317\" lon=\"-122.4525\"/>\n<point lat=\"37.77296\" lon=\"-122.45415\"/>\n<point
+        lat=\"37.7728899\" lon=\"-122.45428\"/>\n<point lat=\"37.77464\" lon=\"-122.45463\"/>\n<point
+        lat=\"37.7749\" lon=\"-122.45346\"/>\n<point lat=\"37.77487\" lon=\"-122.45309\"/>\n</path>\n<path>\n<point
+        lat=\"37.78036\" lon=\"-122.41261\"/>\n<point lat=\"37.7821\" lon=\"-122.4104\"/>\n<point
+        lat=\"37.78389\" lon=\"-122.40814\"/>\n<point lat=\"37.7856499\" lon=\"-122.40589\"/>\n</path>\n<path>\n<point
+        lat=\"37.77487\" lon=\"-122.45309\"/>\n<point lat=\"37.7731\" lon=\"-122.45262\"/>\n<point
+        lat=\"37.77306\" lon=\"-122.45251\"/>\n<point lat=\"37.77342\" lon=\"-122.44946\"/>\n<point
+        lat=\"37.77395\" lon=\"-122.44568\"/>\n</path>\n<path>\n<point lat=\"37.77499\"
+        lon=\"-122.43818\"/>\n<point lat=\"37.77457\" lon=\"-122.4415\"/>\n<point
+        lat=\"37.77443\" lon=\"-122.44263\"/>\n<point lat=\"37.7742\" lon=\"-122.4443\"/>\n<point
+        lat=\"37.77393\" lon=\"-122.44651\"/>\n</path>\n<path>\n<point lat=\"37.77729\"
+        lon=\"-122.42019\"/>\n<point lat=\"37.77689\" lon=\"-122.42333\"/>\n<point
+        lat=\"37.77653\" lon=\"-122.42615\"/>\n<point lat=\"37.77626\" lon=\"-122.42827\"/>\n<point
+        lat=\"37.77606\" lon=\"-122.42988\"/>\n<point lat=\"37.77584\" lon=\"-122.43156\"/>\n<point
+        lat=\"37.77563\" lon=\"-122.4332\"/>\n<point lat=\"37.77547\" lon=\"-122.43444\"/>\n<point
+        lat=\"37.77499\" lon=\"-122.43818\"/>\n</path>\n<path>\n<point lat=\"37.78468\"
+        lon=\"-122.40731\"/>\n<point lat=\"37.78285\" lon=\"-122.40964\"/>\n<point
+        lat=\"37.78057\" lon=\"-122.41244\"/>\n</path>\n<path>\n<point lat=\"37.78861\"
+        lon=\"-122.40216\"/>\n<point lat=\"37.79094\" lon=\"-122.39919\"/>\n<point
+        lat=\"37.79257\" lon=\"-122.39702\"/>\n<point lat=\"37.79378\" lon=\"-122.39563\"/>\n<point
+        lat=\"37.79359\" lon=\"-122.39555\"/>\n<point lat=\"37.79254\" lon=\"-122.39407\"/>\n<point
+        lat=\"37.79322\" lon=\"-122.39319\"/>\n<point lat=\"37.7933499\" lon=\"-122.39323\"/>\n</path>\n<path>\n<point
+        lat=\"37.7933499\" lon=\"-122.39323\"/>\n<point lat=\"37.79443\" lon=\"-122.39455\"/>\n<point
+        lat=\"37.7944699\" lon=\"-122.39476\"/>\n<point lat=\"37.79347\" lon=\"-122.39618\"/>\n<point
+        lat=\"37.79192\" lon=\"-122.39815\"/>\n<point lat=\"37.79016\" lon=\"-122.40041\"/>\n</path>\n<path>\n<point
+        lat=\"37.79016\" lon=\"-122.40041\"/>\n<point lat=\"37.78849\" lon=\"-122.40248\"/>\n<point
+        lat=\"37.78639\" lon=\"-122.40516\"/>\n<point lat=\"37.78468\" lon=\"-122.40731\"/>\n</path>\n<path>\n<point
+        lat=\"37.78861\" lon=\"-122.40216\"/>\n<point lat=\"37.7924\" lon=\"-122.39739\"/>\n<point
+        lat=\"37.79175\" lon=\"-122.3967\"/>\n</path>\n<path>\n<point lat=\"37.77353\"
+        lon=\"-122.46384\"/>\n<point lat=\"37.77487\" lon=\"-122.45309\"/>\n</path>\n<path>\n<point
+        lat=\"37.77395\" lon=\"-122.44568\"/>\n<point lat=\"37.77409\" lon=\"-122.44451\"/>\n<point
+        lat=\"37.77429\" lon=\"-122.44286\"/>\n<point lat=\"37.77451\" lon=\"-122.44126\"/>\n<point
+        lat=\"37.775\" lon=\"-122.4374\"/>\n</path>\n<path>\n<point lat=\"37.78057\"
+        lon=\"-122.41244\"/>\n<point lat=\"37.77878\" lon=\"-122.41472\"/>\n<point
+        lat=\"37.77779\" lon=\"-122.41593\"/>\n<point lat=\"37.77771\" lon=\"-122.41685\"/>\n<point
+        lat=\"37.77729\" lon=\"-122.42019\"/>\n</path>\n</route>\n</body>\n"
+    http_version: 
+  recorded_at: Tue, 26 Mar 2013 19:41:23 GMT
+recorded_with: VCR 2.4.0

--- a/spec/cassettes/Muni_Stop/_predictions/fetches_predictions.yml
+++ b/spec/cassettes/Muni_Stop/_predictions/fetches_predictions.yml
@@ -1,0 +1,478 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://webservices.nextbus.com/service/publicXMLFeed?a=sf-muni&command=routeConfig&r=38
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - '*/*'
+      User-Agent:
+      - Ruby
+      Host:
+      - webservices.nextbus.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 Mar 2013 19:41:23 GMT
+      Server:
+      - Apache/2.2.4 (Unix) mod_ssl/2.2.4 OpenSSL/0.9.7m DAV/2 mod_jk/1.2.30
+      Access-Control-Allow-Origin:
+      - '*'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '3682'
+      Content-Type:
+      - text/xml
+      X-Pad:
+      - avoid browser bug
+    body:
+      encoding: UTF-8
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\" ?> \n<body copyright=\"All
+        data copyright San Francisco Muni 2013.\">\n<route tag=\"38\" title=\"38-Geary\"
+        color=\"ff6633\" oppositeColor=\"000000\" latMin=\"37.7759999\" latMax=\"37.7917499\"
+        lonMin=\"-122.50941\" lonMax=\"-122.3933\">\n<stop tag=\"7620\" title=\"Main
+        St &amp; Howard St\" lat=\"37.7905499\" lon=\"-122.3933\" stopId=\"17620\"/>\n<stop
+        tag=\"5579\" title=\"Mission St &amp; Beale St\" lat=\"37.7911399\" lon=\"-122.39592\"
+        stopId=\"15579\"/>\n<stop tag=\"4725\" title=\"Fremont St &amp; Market St\"
+        lat=\"37.7916499\" lon=\"-122.3981499\" stopId=\"14725\"/>\n<stop tag=\"5689\"
+        title=\"Market St &amp; Sansome St\" lat=\"37.79016\" lon=\"-122.4004099\"
+        stopId=\"15689\"/>\n<stop tag=\"5684\" title=\"Market St &amp; Montgomery
+        St\" lat=\"37.7884899\" lon=\"-122.40248\" stopId=\"15684\"/>\n<stop tag=\"4301\"
+        title=\"Geary Blvd &amp; Kearny St\" lat=\"37.7879999\" lon=\"-122.4036599\"
+        stopId=\"14301\"/>\n<stop tag=\"4766\" title=\"Geary Blvd &amp; Stockton St\"
+        lat=\"37.78764\" lon=\"-122.4064899\" stopId=\"14766\"/>\n<stop tag=\"4757\"
+        title=\"Geary Blvd &amp; Powell St\" lat=\"37.7873999\" lon=\"-122.40839\"
+        stopId=\"14757\"/>\n<stop tag=\"4767\" title=\"Geary Blvd &amp; Taylor St\"
+        lat=\"37.78698\" lon=\"-122.4116799\" stopId=\"14767\"/>\n<stop tag=\"4300\"
+        title=\"Geary Blvd &amp; Jones St\" lat=\"37.78677\" lon=\"-122.4133299\"
+        stopId=\"14300\"/>\n<stop tag=\"4303\" title=\"Geary Blvd &amp; Leavenworth
+        St\" lat=\"37.78656\" lon=\"-122.4149699\" stopId=\"14303\"/>\n<stop tag=\"4299\"
+        title=\"Geary Blvd &amp; Hyde St\" lat=\"37.78635\" lon=\"-122.4166099\" stopId=\"14299\"/>\n<stop
+        tag=\"4302\" title=\"Geary Blvd &amp; Larkin St\" lat=\"37.7861399\" lon=\"-122.41825\"
+        stopId=\"14302\"/>\n<stop tag=\"4768\" title=\"Geary Blvd &amp; Van Ness Ave\"
+        lat=\"37.7858399\" lon=\"-122.42063\" stopId=\"14768\"/>\n<stop tag=\"4297\"
+        title=\"Geary Blvd &amp; Franklin St\" lat=\"37.7855699\" lon=\"-122.42289\"
+        stopId=\"14297\"/>\n<stop tag=\"4298\" title=\"Geary Blvd &amp; Gough St\"
+        lat=\"37.7854299\" lon=\"-122.4250799\" stopId=\"14298\"/>\n<stop tag=\"4304\"
+        title=\"Geary Blvd &amp; Laguna St\" lat=\"37.78503\" lon=\"-122.4278099\"
+        stopId=\"14304\"/>\n<stop tag=\"4769\" title=\"Geary Blvd &amp; Webster St\"
+        lat=\"37.7846399\" lon=\"-122.43102\" stopId=\"14769\"/>\n<stop tag=\"4295\"
+        title=\"Geary Blvd &amp; Fillmore St\" lat=\"37.7843899\" lon=\"-122.43305\"
+        stopId=\"14295\"/>\n<stop tag=\"4760\" title=\"Geary Blvd &amp; Scott St\"
+        lat=\"37.78385\" lon=\"-122.4377599\" stopId=\"14760\"/>\n<stop tag=\"4293\"
+        title=\"Geary Blvd &amp; Divisadero St\" lat=\"37.78343\" lon=\"-122.4393699\"
+        stopId=\"14293\"/>\n<stop tag=\"4289\" title=\"Geary Blvd &amp; Baker St\"
+        lat=\"37.7829699\" lon=\"-122.44296\" stopId=\"14289\"/>\n<stop tag=\"4758\"
+        title=\"Geary Blvd &amp; Presidio Ave\" lat=\"37.7825099\" lon=\"-122.4468\"
+        stopId=\"14758\"/>\n<stop tag=\"4290\" title=\"Geary Blvd &amp; Collins St\"
+        lat=\"37.78224\" lon=\"-122.4499899\" stopId=\"14290\"/>\n<stop tag=\"4762\"
+        title=\"Geary Blvd &amp; Spruce St\" lat=\"37.7818499\" lon=\"-122.45307\"
+        stopId=\"14762\"/>\n<stop tag=\"4292\" title=\"Geary Blvd &amp; Commonwealth
+        St\" lat=\"37.7815299\" lon=\"-122.45568\" stopId=\"14292\"/>\n<stop tag=\"4287\"
+        title=\"Geary Blvd &amp; Arguello Blvd\" lat=\"37.7813799\" lon=\"-122.45874\"
+        stopId=\"14287\"/>\n<stop tag=\"4255\" title=\"Geary Blvd &amp; 3rd Ave\"
+        lat=\"37.78128\" lon=\"-122.4609399\" stopId=\"14255\"/>\n<stop tag=\"4257\"
+        title=\"Geary Blvd &amp; 6th Ave\" lat=\"37.7811299\" lon=\"-122.46416\" stopId=\"14257\"/>\n<stop
+        tag=\"4259\" title=\"Geary Blvd &amp; 9th Ave\" lat=\"37.78098\" lon=\"-122.4676399\"
+        stopId=\"14259\"/>\n<stop tag=\"4261\" title=\"Geary Blvd &amp; 12th Ave\"
+        lat=\"37.78084\" lon=\"-122.4705999\" stopId=\"14261\"/>\n<stop tag=\"4755\"
+        title=\"Geary Blvd &amp; Park Presidio Blvd\" lat=\"37.7806899\" lon=\"-122.47242\"
+        stopId=\"14755\"/>\n<stop tag=\"4263\" title=\"Geary Blvd &amp; 17th Ave\"
+        lat=\"37.7805999\" lon=\"-122.47604\" stopId=\"14263\"/>\n<stop tag=\"4265\"
+        title=\"Geary Blvd &amp; 20th Ave\" lat=\"37.78045\" lon=\"-122.4792699\"
+        stopId=\"14265\"/>\n<stop tag=\"4267\" title=\"Geary Blvd &amp; 22nd Ave\"
+        lat=\"37.78035\" lon=\"-122.4813999\" stopId=\"14267\"/>\n<stop tag=\"4269\"
+        title=\"Geary Blvd &amp; 25th Ave\" lat=\"37.7802199\" lon=\"-122.48461\"
+        stopId=\"14269\"/>\n<stop tag=\"4271\" title=\"Geary Blvd &amp; 28th Ave\"
+        lat=\"37.7800099\" lon=\"-122.48781\" stopId=\"14271\"/>\n<stop tag=\"4273\"
+        title=\"Geary Blvd &amp; 30th Ave\" lat=\"37.7799599\" lon=\"-122.48997\"
+        stopId=\"14273\"/>\n<stop tag=\"3560\" title=\"33rd Ave &amp; Geary Blvd\"
+        lat=\"37.7795699\" lon=\"-122.49338\" stopId=\"13560\"/>\n<stop tag=\"3551\"
+        title=\"33rd Ave &amp; Anza St\" lat=\"37.77786\" lon=\"-122.49325\" stopId=\"13551\"/>\n<stop
+        tag=\"3554\" title=\"33rd Ave &amp; Balboa St\" lat=\"37.7759999\" lon=\"-122.4931299\"
+        stopId=\"13554\"/>\n<stop tag=\"33545\" title=\"32nd Ave &amp; Balboa St\"
+        lat=\"37.7766799\" lon=\"-122.49195\" stopId=\"133545\"/>\n<stop tag=\"4278\"
+        title=\"Geary Blvd &amp; 33rd Ave\" lat=\"37.7797999\" lon=\"-122.49344\"
+        stopId=\"14278\"/>\n<stop tag=\"4280\" title=\"Geary Blvd &amp; 36th Ave\"
+        lat=\"37.7796699\" lon=\"-122.4964\" stopId=\"14280\"/>\n<stop tag=\"4282\"
+        title=\"Geary Blvd &amp; 40th Ave\" lat=\"37.7794699\" lon=\"-122.50068\"
+        stopId=\"14282\"/>\n<stop tag=\"6109\" title=\"Point Lobos Ave &amp; 42nd
+        Ave\" lat=\"37.7796499\" lon=\"-122.5028499\" stopId=\"16109\"/>\n<stop tag=\"3566\"
+        title=\"42nd Ave &amp; Clement St\" lat=\"37.7810899\" lon=\"-122.5029899\"
+        stopId=\"13566\"/>\n<stop tag=\"5511\" title=\"Fort Miley Hospital\" lat=\"37.7818299\"
+        lon=\"-122.50411\" stopId=\"15511\"/>\n<stop tag=\"3567\" title=\"43rd Ave
+        &amp; Clement St\" lat=\"37.78101\" lon=\"-122.5042299\" stopId=\"13567\"/>\n<stop
+        tag=\"3568\" title=\"43rd Ave &amp; Point Lobos Ave\" lat=\"37.7797799\" lon=\"-122.5041399\"
+        stopId=\"13568\"/>\n<stop tag=\"6111\" title=\"Point Lobos Ave &amp; 44th
+        Ave\" lat=\"37.77984\" lon=\"-122.50501\" stopId=\"16111\"/>\n<stop tag=\"6129\"
+        title=\"Point Lobos Ave &amp; 46th Ave\" lat=\"37.7800399\" lon=\"-122.50744\"
+        stopId=\"16129\"/>\n<stop tag=\"33608\" title=\"48th Ave &amp; Point Lobos
+        Ave\" lat=\"37.7790199\" lon=\"-122.50941\" stopId=\"133608\"/>\n<stop tag=\"35511\"
+        title=\"Fort Miley Hospital\" lat=\"37.7818299\" lon=\"-122.50411\" stopId=\"135511\"/>\n<stop
+        tag=\"3545\" title=\"32nd Ave &amp; Balboa St\" lat=\"37.7766799\" lon=\"-122.49195\"
+        stopId=\"13545\"/>\n<stop tag=\"3635\" title=\"Anza St &amp; 33rd Ave\" lat=\"37.7778499\"
+        lon=\"-122.4930299\" stopId=\"13635\"/>\n<stop tag=\"3559\" title=\"33rd Ave
+        &amp; Geary Blvd\" lat=\"37.7795499\" lon=\"-122.49321\" stopId=\"13559\"/>\n<stop
+        tag=\"4275\" title=\"Geary Blvd &amp; 32nd Ave\" lat=\"37.77965\" lon=\"-122.4920699\"
+        stopId=\"14275\"/>\n<stop tag=\"4274\" title=\"Geary Blvd &amp; 30th Ave\"
+        lat=\"37.77973\" lon=\"-122.4901899\" stopId=\"14274\"/>\n<stop tag=\"4272\"
+        title=\"Geary Blvd &amp; 28th Ave\" lat=\"37.7798599\" lon=\"-122.48805\"
+        stopId=\"14272\"/>\n<stop tag=\"4270\" title=\"Geary Blvd &amp; 25th Ave\"
+        lat=\"37.7799799\" lon=\"-122.48482\" stopId=\"14270\"/>\n<stop tag=\"4268\"
+        title=\"Geary Blvd &amp; 23rd Ave\" lat=\"37.78008\" lon=\"-122.4826899\"
+        stopId=\"14268\"/>\n<stop tag=\"4266\" title=\"Geary Blvd &amp; 20th Ave\"
+        lat=\"37.7802199\" lon=\"-122.47948\" stopId=\"14266\"/>\n<stop tag=\"4264\"
+        title=\"Geary Blvd &amp; 17th Ave\" lat=\"37.78037\" lon=\"-122.4762599\"
+        stopId=\"14264\"/>\n<stop tag=\"4756\" title=\"Geary Blvd &amp; Park Presidio
+        Blvd\" lat=\"37.7805299\" lon=\"-122.47268\" stopId=\"14756\"/>\n<stop tag=\"4262\"
+        title=\"Geary Blvd &amp; 12th Ave\" lat=\"37.7806099\" lon=\"-122.47082\"
+        stopId=\"14262\"/>\n<stop tag=\"4260\" title=\"Geary Blvd &amp; 9th Ave\"
+        lat=\"37.78078\" lon=\"-122.4673199\" stopId=\"14260\"/>\n<stop tag=\"4258\"
+        title=\"Geary Blvd &amp; 6th Ave\" lat=\"37.7808999\" lon=\"-122.46438\" stopId=\"14258\"/>\n<stop
+        tag=\"4256\" title=\"Geary Blvd &amp; 3rd Ave\" lat=\"37.78105\" lon=\"-122.4611599\"
+        stopId=\"14256\"/>\n<stop tag=\"4288\" title=\"Geary Blvd &amp; Arguello Blvd\"
+        lat=\"37.7811499\" lon=\"-122.45869\" stopId=\"14288\"/>\n<stop tag=\"4764\"
+        title=\"Geary Blvd &amp; Stanyan St\" lat=\"37.7812599\" lon=\"-122.45643\"
+        stopId=\"14764\"/>\n<stop tag=\"4763\" title=\"Geary Blvd &amp; Spruce St\"
+        lat=\"37.7816\" lon=\"-122.4532599\" stopId=\"14763\"/>\n<stop tag=\"4291\"
+        title=\"Geary Blvd &amp; Collins St\" lat=\"37.78203\" lon=\"-122.4499099\"
+        stopId=\"14291\"/>\n<stop tag=\"4754\" title=\"Geary Blvd &amp; Masonic Ave\"
+        lat=\"37.78223\" lon=\"-122.4476299\" stopId=\"14754\"/>\n<stop tag=\"4759\"
+        title=\"Geary Blvd &amp; Presidio Ave\" lat=\"37.7823199\" lon=\"-122.44593\"
+        stopId=\"14759\"/>\n<stop tag=\"4765\" title=\"Geary Blvd &amp; St Joseph&apos;S
+        Ave\" lat=\"37.7828\" lon=\"-122.4425399\" stopId=\"14765\"/>\n<stop tag=\"4294\"
+        title=\"Geary Blvd &amp; Divisadero St\" lat=\"37.7831799\" lon=\"-122.43957\"
+        stopId=\"14294\"/>\n<stop tag=\"4761\" title=\"Geary Blvd &amp; Scott St\"
+        lat=\"37.78362\" lon=\"-122.4376699\" stopId=\"14761\"/>\n<stop tag=\"4296\"
+        title=\"Geary Blvd &amp; Fillmore St\" lat=\"37.7842599\" lon=\"-122.43331\"
+        stopId=\"14296\"/>\n<stop tag=\"4770\" title=\"Geary Blvd &amp; Webster St\"
+        lat=\"37.7844899\" lon=\"-122.43135\" stopId=\"14770\"/>\n<stop tag=\"4305\"
+        title=\"Geary Blvd &amp; Laguna St\" lat=\"37.78485\" lon=\"-122.4281499\"
+        stopId=\"14305\"/>\n<stop tag=\"6425\" title=\"Starr King Way &amp; Gough
+        St\" lat=\"37.7850499\" lon=\"-122.4240799\" stopId=\"16425\"/>\n<stop tag=\"5818\"
+        title=\"O&apos;Farrell St &amp; Van Ness Ave\" lat=\"37.7846599\" lon=\"-122.42141\"
+        stopId=\"15818\"/>\n<stop tag=\"5813\" title=\"O&apos;Farrell St &amp; Larkin
+        St\" lat=\"37.78509\" lon=\"-122.4179999\" stopId=\"15813\"/>\n<stop tag=\"5811\"
+        title=\"O&apos;Farrell St &amp; Hyde St\" lat=\"37.78537\" lon=\"-122.4157699\"
+        stopId=\"15811\"/>\n<stop tag=\"5814\" title=\"O&apos;Farrell St &amp; Leavenworth
+        St\" lat=\"37.78554\" lon=\"-122.4144399\" stopId=\"15814\"/>\n<stop tag=\"7301\"
+        title=\"O&apos;Farrell St &amp; Taylor St\" lat=\"37.7858499\" lon=\"-122.41198\"
+        stopId=\"17301\"/>\n<stop tag=\"5817\" title=\"O&apos;Farrell St &amp; Powell
+        St\" lat=\"37.7863299\" lon=\"-122.40813\" stopId=\"15817\"/>\n<stop tag=\"5810\"
+        title=\"O&apos;Farrell St &amp; Grant Ave\" lat=\"37.7866399\" lon=\"-122.40563\"
+        stopId=\"15810\"/>\n<stop tag=\"5641\" title=\"Market St &amp; 3rd St\" lat=\"37.7877099\"
+        lon=\"-122.40321\" stopId=\"15641\"/>\n<stop tag=\"5638\" title=\"Market St
+        &amp; 1st St\" lat=\"37.7909\" lon=\"-122.3991399\" stopId=\"15638\"/>\n<stop
+        tag=\"3089\" title=\"Beale St &amp; Mission St\" lat=\"37.7917499\" lon=\"-122.3966999\"
+        stopId=\"13089\"/>\n<stop tag=\"7619\" title=\"Bealemst &amp; Howard St\"
+        lat=\"37.78969\" lon=\"-122.39404\" stopId=\"17619\"/>\n<stop tag=\"3608\"
+        title=\"48th Ave &amp; Point Lobos Ave\" lat=\"37.7790199\" lon=\"-122.50941\"
+        stopId=\"13608\"/>\n<stop tag=\"4286\" title=\"Geary Blvd &amp; 45th Ave\"
+        lat=\"37.7790399\" lon=\"-122.50626\" stopId=\"14286\"/>\n<stop tag=\"4285\"
+        title=\"Geary Blvd &amp; 42nd Ave\" lat=\"37.77915\" lon=\"-122.5027699\"
+        stopId=\"14285\"/>\n<stop tag=\"4283\" title=\"Geary Blvd &amp; 39th Ave\"
+        lat=\"37.7792899\" lon=\"-122.49983\" stopId=\"14283\"/>\n<stop tag=\"4281\"
+        title=\"Geary Blvd &amp; 36th Ave\" lat=\"37.77944\" lon=\"-122.4966199\"
+        stopId=\"14281\"/>\n<stop tag=\"4279\" title=\"Geary Blvd &amp; 33rd Ave\"
+        lat=\"37.7795699\" lon=\"-122.4934\" stopId=\"14279\"/>\n<stop tag=\"15511\"
+        title=\"Fort Miley Hospital\" lat=\"37.7818299\" lon=\"-122.50411\" stopId=\"115511\"/>\n<stop
+        tag=\"13567\" title=\"43rd Ave &amp; Clement St\" lat=\"37.78101\" lon=\"-122.5042299\"
+        stopId=\"113567\"/>\n<stop tag=\"13568\" title=\"43rd Ave &amp; Point Lobos
+        Ave\" lat=\"37.7797799\" lon=\"-122.5041399\" stopId=\"113568\"/>\n<direction
+        tag=\"38_IB3\" title=\"Inbound to Downtown\" name=\"Inbound\" useForUI=\"true\">\n
+        \ <stop tag=\"15511\" />\n  <stop tag=\"13567\" />\n  <stop tag=\"13568\"
+        />\n  <stop tag=\"4285\" />\n  <stop tag=\"4283\" />\n  <stop tag=\"4281\"
+        />\n  <stop tag=\"4279\" />\n  <stop tag=\"4275\" />\n  <stop tag=\"4274\"
+        />\n  <stop tag=\"4272\" />\n  <stop tag=\"4270\" />\n  <stop tag=\"4268\"
+        />\n  <stop tag=\"4266\" />\n  <stop tag=\"4264\" />\n  <stop tag=\"4756\"
+        />\n  <stop tag=\"4262\" />\n  <stop tag=\"4260\" />\n  <stop tag=\"4258\"
+        />\n  <stop tag=\"4256\" />\n  <stop tag=\"4288\" />\n  <stop tag=\"4764\"
+        />\n  <stop tag=\"4763\" />\n  <stop tag=\"4291\" />\n  <stop tag=\"4754\"
+        />\n  <stop tag=\"4759\" />\n  <stop tag=\"4765\" />\n  <stop tag=\"4294\"
+        />\n  <stop tag=\"4761\" />\n  <stop tag=\"4296\" />\n  <stop tag=\"4770\"
+        />\n  <stop tag=\"4305\" />\n  <stop tag=\"6425\" />\n  <stop tag=\"5818\"
+        />\n  <stop tag=\"5813\" />\n  <stop tag=\"5811\" />\n  <stop tag=\"5814\"
+        />\n  <stop tag=\"7301\" />\n  <stop tag=\"5817\" />\n  <stop tag=\"5810\"
+        />\n  <stop tag=\"5641\" />\n  <stop tag=\"5638\" />\n  <stop tag=\"3089\"
+        />\n  <stop tag=\"7619\" />\n</direction>\n<direction tag=\"38_IB2\" title=\"Inbound
+        to Downtown\" name=\"Inbound\" useForUI=\"true\">\n  <stop tag=\"3608\" />\n
+        \ <stop tag=\"4286\" />\n  <stop tag=\"4285\" />\n  <stop tag=\"4283\" />\n
+        \ <stop tag=\"4281\" />\n  <stop tag=\"4279\" />\n  <stop tag=\"4275\" />\n
+        \ <stop tag=\"4274\" />\n  <stop tag=\"4272\" />\n  <stop tag=\"4270\" />\n
+        \ <stop tag=\"4268\" />\n  <stop tag=\"4266\" />\n  <stop tag=\"4264\" />\n
+        \ <stop tag=\"4756\" />\n  <stop tag=\"4262\" />\n  <stop tag=\"4260\" />\n
+        \ <stop tag=\"4258\" />\n  <stop tag=\"4256\" />\n  <stop tag=\"4288\" />\n
+        \ <stop tag=\"4764\" />\n  <stop tag=\"4763\" />\n  <stop tag=\"4291\" />\n
+        \ <stop tag=\"4754\" />\n  <stop tag=\"4759\" />\n  <stop tag=\"4765\" />\n
+        \ <stop tag=\"4294\" />\n  <stop tag=\"4761\" />\n  <stop tag=\"4296\" />\n
+        \ <stop tag=\"4770\" />\n  <stop tag=\"4305\" />\n  <stop tag=\"6425\" />\n
+        \ <stop tag=\"5818\" />\n  <stop tag=\"5813\" />\n  <stop tag=\"5811\" />\n
+        \ <stop tag=\"5814\" />\n  <stop tag=\"7301\" />\n  <stop tag=\"5817\" />\n
+        \ <stop tag=\"5810\" />\n  <stop tag=\"5641\" />\n  <stop tag=\"5638\" />\n
+        \ <stop tag=\"3089\" />\n  <stop tag=\"7619\" />\n</direction>\n<direction
+        tag=\"38_IB1\" title=\"Inbound to Downtown\" name=\"Inbound\" useForUI=\"true\">\n
+        \ <stop tag=\"3545\" />\n  <stop tag=\"3635\" />\n  <stop tag=\"3559\" />\n
+        \ <stop tag=\"4275\" />\n  <stop tag=\"4274\" />\n  <stop tag=\"4272\" />\n
+        \ <stop tag=\"4270\" />\n  <stop tag=\"4268\" />\n  <stop tag=\"4266\" />\n
+        \ <stop tag=\"4264\" />\n  <stop tag=\"4756\" />\n  <stop tag=\"4262\" />\n
+        \ <stop tag=\"4260\" />\n  <stop tag=\"4258\" />\n  <stop tag=\"4256\" />\n
+        \ <stop tag=\"4288\" />\n  <stop tag=\"4764\" />\n  <stop tag=\"4763\" />\n
+        \ <stop tag=\"4291\" />\n  <stop tag=\"4754\" />\n  <stop tag=\"4759\" />\n
+        \ <stop tag=\"4765\" />\n  <stop tag=\"4294\" />\n  <stop tag=\"4761\" />\n
+        \ <stop tag=\"4296\" />\n  <stop tag=\"4770\" />\n  <stop tag=\"4305\" />\n
+        \ <stop tag=\"6425\" />\n  <stop tag=\"5818\" />\n  <stop tag=\"5813\" />\n
+        \ <stop tag=\"5811\" />\n  <stop tag=\"5814\" />\n  <stop tag=\"7301\" />\n
+        \ <stop tag=\"5817\" />\n  <stop tag=\"5810\" />\n  <stop tag=\"5641\" />\n
+        \ <stop tag=\"5638\" />\n  <stop tag=\"3089\" />\n  <stop tag=\"7619\" />\n</direction>\n<direction
+        tag=\"38_OB3\" title=\"Outbound to the Richmond District\" name=\"Outbound\"
+        useForUI=\"true\">\n  <stop tag=\"7620\" />\n  <stop tag=\"5579\" />\n  <stop
+        tag=\"4725\" />\n  <stop tag=\"5689\" />\n  <stop tag=\"5684\" />\n  <stop
+        tag=\"4301\" />\n  <stop tag=\"4766\" />\n  <stop tag=\"4757\" />\n  <stop
+        tag=\"4767\" />\n  <stop tag=\"4300\" />\n  <stop tag=\"4303\" />\n  <stop
+        tag=\"4299\" />\n  <stop tag=\"4302\" />\n  <stop tag=\"4768\" />\n  <stop
+        tag=\"4297\" />\n  <stop tag=\"4298\" />\n  <stop tag=\"4304\" />\n  <stop
+        tag=\"4769\" />\n  <stop tag=\"4295\" />\n  <stop tag=\"4760\" />\n  <stop
+        tag=\"4293\" />\n  <stop tag=\"4289\" />\n  <stop tag=\"4758\" />\n  <stop
+        tag=\"4290\" />\n  <stop tag=\"4762\" />\n  <stop tag=\"4292\" />\n  <stop
+        tag=\"4287\" />\n  <stop tag=\"4255\" />\n  <stop tag=\"4257\" />\n  <stop
+        tag=\"4259\" />\n  <stop tag=\"4261\" />\n  <stop tag=\"4755\" />\n  <stop
+        tag=\"4263\" />\n  <stop tag=\"4265\" />\n  <stop tag=\"4267\" />\n  <stop
+        tag=\"4269\" />\n  <stop tag=\"4271\" />\n  <stop tag=\"4273\" />\n  <stop
+        tag=\"4278\" />\n  <stop tag=\"4280\" />\n  <stop tag=\"4282\" />\n  <stop
+        tag=\"6109\" />\n  <stop tag=\"3566\" />\n  <stop tag=\"5511\" />\n  <stop
+        tag=\"3567\" />\n  <stop tag=\"3568\" />\n  <stop tag=\"6111\" />\n  <stop
+        tag=\"6129\" />\n  <stop tag=\"33608\" />\n</direction>\n<path>\n<point lat=\"37.78771\"
+        lon=\"-122.40321\"/>\n<point lat=\"37.7909\" lon=\"-122.39914\"/>\n<point
+        lat=\"37.7924099\" lon=\"-122.39738\"/>\n<point lat=\"37.79175\" lon=\"-122.3967\"/>\n<point
+        lat=\"37.78993\" lon=\"-122.39428\"/>\n<point lat=\"37.78969\" lon=\"-122.39404\"/>\n</path>\n<path>\n<point
+        lat=\"37.78584\" lon=\"-122.42063\"/>\n<point lat=\"37.78557\" lon=\"-122.42289\"/>\n<point
+        lat=\"37.78541\" lon=\"-122.42355\"/>\n<point lat=\"37.7854\" lon=\"-122.42444\"/>\n<point
+        lat=\"37.78543\" lon=\"-122.42508\"/>\n<point lat=\"37.78503\" lon=\"-122.42781\"/>\n<point
+        lat=\"37.78464\" lon=\"-122.43102\"/>\n<point lat=\"37.78439\" lon=\"-122.43305\"/>\n</path>\n<path>\n<point
+        lat=\"37.78053\" lon=\"-122.47268\"/>\n<point lat=\"37.78061\" lon=\"-122.47082\"/>\n<point
+        lat=\"37.78078\" lon=\"-122.46732\"/>\n<point lat=\"37.7809\" lon=\"-122.46438\"/>\n<point
+        lat=\"37.78105\" lon=\"-122.46116\"/>\n<point lat=\"37.7811499\" lon=\"-122.45869\"/>\n<point
+        lat=\"37.78126\" lon=\"-122.45643\"/>\n<point lat=\"37.7816\" lon=\"-122.45326\"/>\n<point
+        lat=\"37.78203\" lon=\"-122.44991\"/>\n<point lat=\"37.78229\" lon=\"-122.44789\"/>\n<point
+        lat=\"37.78223\" lon=\"-122.44763\"/>\n<point lat=\"37.7822699\" lon=\"-122.44754\"/>\n<point
+        lat=\"37.78222\" lon=\"-122.44723\"/>\n<point lat=\"37.78232\" lon=\"-122.44593\"/>\n</path>\n<path>\n<point
+        lat=\"37.78069\" lon=\"-122.47242\"/>\n<point lat=\"37.7806\" lon=\"-122.47604\"/>\n<point
+        lat=\"37.78045\" lon=\"-122.47927\"/>\n<point lat=\"37.78035\" lon=\"-122.4814\"/>\n<point
+        lat=\"37.78022\" lon=\"-122.48461\"/>\n<point lat=\"37.78001\" lon=\"-122.48781\"/>\n<point
+        lat=\"37.77996\" lon=\"-122.48997\"/>\n<point lat=\"37.7798\" lon=\"-122.49344\"/>\n</path>\n<path>\n<point
+        lat=\"37.78849\" lon=\"-122.40248\"/>\n<point lat=\"37.7880899\" lon=\"-122.4029\"/>\n<point
+        lat=\"37.78796\" lon=\"-122.40349\"/>\n<point lat=\"37.7879999\" lon=\"-122.40366\"/>\n<point
+        lat=\"37.78764\" lon=\"-122.40649\"/>\n<point lat=\"37.7874\" lon=\"-122.40839\"/>\n</path>\n<path>\n<point
+        lat=\"37.78426\" lon=\"-122.43331\"/>\n<point lat=\"37.78449\" lon=\"-122.43135\"/>\n<point
+        lat=\"37.78485\" lon=\"-122.42815\"/>\n<point lat=\"37.78534\" lon=\"-122.42469\"/>\n<point
+        lat=\"37.78519\" lon=\"-122.42417\"/>\n<point lat=\"37.78505\" lon=\"-122.42408\"/>\n<point
+        lat=\"37.7849999\" lon=\"-122.42387\"/>\n<point lat=\"37.78477\" lon=\"-122.42361\"/>\n<point
+        lat=\"37.7846199\" lon=\"-122.42332\"/>\n<point lat=\"37.78455\" lon=\"-122.42304\"/>\n<point
+        lat=\"37.78466\" lon=\"-122.42141\"/>\n</path>\n<path>\n<point lat=\"37.79055\"
+        lon=\"-122.3933\"/>\n<point lat=\"37.79184\" lon=\"-122.39494\"/>\n<point
+        lat=\"37.79114\" lon=\"-122.39592\"/>\n<point lat=\"37.79046\" lon=\"-122.39669\"/>\n<point
+        lat=\"37.79165\" lon=\"-122.39815\"/>\n<point lat=\"37.79172\" lon=\"-122.39826\"/>\n<point
+        lat=\"37.79016\" lon=\"-122.40041\"/>\n<point lat=\"37.78849\" lon=\"-122.40248\"/>\n</path>\n<path>\n<point
+        lat=\"37.78466\" lon=\"-122.42141\"/>\n<point lat=\"37.7850899\" lon=\"-122.418\"/>\n<point
+        lat=\"37.78537\" lon=\"-122.41577\"/>\n<point lat=\"37.78554\" lon=\"-122.41444\"/>\n<point
+        lat=\"37.78585\" lon=\"-122.41198\"/>\n<point lat=\"37.78633\" lon=\"-122.40813\"/>\n</path>\n<path>\n<point
+        lat=\"37.78251\" lon=\"-122.4468\"/>\n<point lat=\"37.78239\" lon=\"-122.4473\"/>\n<point
+        lat=\"37.78248\" lon=\"-122.44806\"/>\n<point lat=\"37.78224\" lon=\"-122.44999\"/>\n<point
+        lat=\"37.78185\" lon=\"-122.45307\"/>\n<point lat=\"37.7815299\" lon=\"-122.45568\"/>\n<point
+        lat=\"37.78138\" lon=\"-122.45874\"/>\n<point lat=\"37.78128\" lon=\"-122.46094\"/>\n<point
+        lat=\"37.78113\" lon=\"-122.46416\"/>\n<point lat=\"37.78098\" lon=\"-122.46764\"/>\n<point
+        lat=\"37.78084\" lon=\"-122.4706\"/>\n<point lat=\"37.78069\" lon=\"-122.47242\"/>\n</path>\n<path>\n<point
+        lat=\"37.78232\" lon=\"-122.44593\"/>\n<point lat=\"37.7828\" lon=\"-122.44254\"/>\n<point
+        lat=\"37.78318\" lon=\"-122.43957\"/>\n<point lat=\"37.78343\" lon=\"-122.43864\"/>\n<point
+        lat=\"37.78367\" lon=\"-122.43803\"/>\n<point lat=\"37.78362\" lon=\"-122.43767\"/>\n<point
+        lat=\"37.78426\" lon=\"-122.43331\"/>\n</path>\n<path>\n<point lat=\"37.78633\"
+        lon=\"-122.40813\"/>\n<point lat=\"37.78664\" lon=\"-122.40563\"/>\n<point
+        lat=\"37.78681\" lon=\"-122.40485\"/>\n<point lat=\"37.78673\" lon=\"-122.40458\"/>\n<point
+        lat=\"37.78771\" lon=\"-122.40321\"/>\n</path>\n<path>\n<point lat=\"37.7874\"
+        lon=\"-122.40839\"/>\n<point lat=\"37.78698\" lon=\"-122.41168\"/>\n<point
+        lat=\"37.78677\" lon=\"-122.41333\"/>\n<point lat=\"37.78656\" lon=\"-122.41497\"/>\n<point
+        lat=\"37.78635\" lon=\"-122.41661\"/>\n<point lat=\"37.78614\" lon=\"-122.41825\"/>\n<point
+        lat=\"37.78584\" lon=\"-122.42063\"/>\n</path>\n<path>\n<point lat=\"37.78183\"
+        lon=\"-122.50411\"/>\n<point lat=\"37.78197\" lon=\"-122.50458\"/>\n<point
+        lat=\"37.78202\" lon=\"-122.50492\"/>\n<point lat=\"37.78208\" lon=\"-122.50711\"/>\n<point
+        lat=\"37.78216\" lon=\"-122.50738\"/>\n<point lat=\"37.78195\" lon=\"-122.5076\"/>\n<point
+        lat=\"37.78173\" lon=\"-122.50739\"/>\n<point lat=\"37.78159\" lon=\"-122.50708\"/>\n<point
+        lat=\"37.7815299\" lon=\"-122.5067\"/>\n<point lat=\"37.78159\" lon=\"-122.50634\"/>\n<point
+        lat=\"37.7816\" lon=\"-122.506\"/>\n<point lat=\"37.78143\" lon=\"-122.5057\"/>\n<point
+        lat=\"37.78132\" lon=\"-122.50439\"/>\n<point lat=\"37.78113\" lon=\"-122.50416\"/>\n<point
+        lat=\"37.78101\" lon=\"-122.50423\"/>\n<point lat=\"37.77978\" lon=\"-122.50414\"/>\n<point
+        lat=\"37.77971\" lon=\"-122.50406\"/>\n<point lat=\"37.77984\" lon=\"-122.50501\"/>\n<point
+        lat=\"37.77998\" lon=\"-122.5073\"/>\n<point lat=\"37.78004\" lon=\"-122.50744\"/>\n<point
+        lat=\"37.77985\" lon=\"-122.50943\"/>\n<point lat=\"37.77902\" lon=\"-122.50941\"/>\n</path>\n<path>\n<point
+        lat=\"37.78069\" lon=\"-122.47242\"/>\n<point lat=\"37.7806\" lon=\"-122.47604\"/>\n<point
+        lat=\"37.78045\" lon=\"-122.47927\"/>\n<point lat=\"37.78035\" lon=\"-122.4814\"/>\n<point
+        lat=\"37.78022\" lon=\"-122.48461\"/>\n<point lat=\"37.78001\" lon=\"-122.48781\"/>\n<point
+        lat=\"37.77996\" lon=\"-122.48997\"/>\n<point lat=\"37.77969\" lon=\"-122.4933\"/>\n<point
+        lat=\"37.77957\" lon=\"-122.49338\"/>\n</path>\n<path>\n<point lat=\"37.78439\"
+        lon=\"-122.43305\"/>\n<point lat=\"37.78385\" lon=\"-122.43776\"/>\n<point
+        lat=\"37.78372\" lon=\"-122.43785\"/>\n<point lat=\"37.78343\" lon=\"-122.43864\"/>\n<point
+        lat=\"37.78343\" lon=\"-122.43937\"/>\n<point lat=\"37.78297\" lon=\"-122.44296\"/>\n<point
+        lat=\"37.78251\" lon=\"-122.4468\"/>\n</path>\n<path>\n<point lat=\"37.7798\"
+        lon=\"-122.49344\"/>\n<point lat=\"37.77967\" lon=\"-122.4964\"/>\n<point
+        lat=\"37.77947\" lon=\"-122.50068\"/>\n<point lat=\"37.77935\" lon=\"-122.5008\"/>\n<point
+        lat=\"37.7796499\" lon=\"-122.50285\"/>\n<point lat=\"37.77961\" lon=\"-122.50297\"/>\n<point
+        lat=\"37.78109\" lon=\"-122.50299\"/>\n<point lat=\"37.78118\" lon=\"-122.50309\"/>\n<point
+        lat=\"37.78139\" lon=\"-122.5032\"/>\n<point lat=\"37.78148\" lon=\"-122.50357\"/>\n<point
+        lat=\"37.78183\" lon=\"-122.50411\"/>\n</path>\n<path>\n<point lat=\"37.77955\"
+        lon=\"-122.49321\"/>\n<point lat=\"37.77969\" lon=\"-122.4933\"/>\n<point
+        lat=\"37.7796499\" lon=\"-122.49207\"/>\n<point lat=\"37.77973\" lon=\"-122.49019\"/>\n<point
+        lat=\"37.77986\" lon=\"-122.48805\"/>\n<point lat=\"37.77998\" lon=\"-122.48482\"/>\n<point
+        lat=\"37.78008\" lon=\"-122.48269\"/>\n<point lat=\"37.78022\" lon=\"-122.47948\"/>\n<point
+        lat=\"37.78037\" lon=\"-122.47626\"/>\n<point lat=\"37.78053\" lon=\"-122.47268\"/>\n</path>\n<path>\n<point
+        lat=\"37.78183\" lon=\"-122.50411\"/>\n<point lat=\"37.78197\" lon=\"-122.50458\"/>\n<point
+        lat=\"37.78202\" lon=\"-122.50492\"/>\n<point lat=\"37.78208\" lon=\"-122.50711\"/>\n<point
+        lat=\"37.78216\" lon=\"-122.50738\"/>\n<point lat=\"37.78195\" lon=\"-122.5076\"/>\n<point
+        lat=\"37.78173\" lon=\"-122.50739\"/>\n<point lat=\"37.78159\" lon=\"-122.50708\"/>\n<point
+        lat=\"37.7815299\" lon=\"-122.5067\"/>\n<point lat=\"37.78159\" lon=\"-122.50634\"/>\n<point
+        lat=\"37.7816\" lon=\"-122.506\"/>\n<point lat=\"37.78143\" lon=\"-122.5057\"/>\n<point
+        lat=\"37.78132\" lon=\"-122.50439\"/>\n<point lat=\"37.78113\" lon=\"-122.50416\"/>\n<point
+        lat=\"37.78101\" lon=\"-122.50423\"/>\n<point lat=\"37.77978\" lon=\"-122.50414\"/>\n<point
+        lat=\"37.77921\" lon=\"-122.50402\"/>\n<point lat=\"37.77915\" lon=\"-122.50277\"/>\n<point
+        lat=\"37.77929\" lon=\"-122.49983\"/>\n<point lat=\"37.77944\" lon=\"-122.49662\"/>\n<point
+        lat=\"37.77957\" lon=\"-122.4934\"/>\n</path>\n<path>\n<point lat=\"37.77668\"
+        lon=\"-122.49195\"/>\n<point lat=\"37.77782\" lon=\"-122.49209\"/>\n<point
+        lat=\"37.77785\" lon=\"-122.49303\"/>\n<point lat=\"37.7777699\" lon=\"-122.49317\"/>\n<point
+        lat=\"37.77955\" lon=\"-122.49321\"/>\n</path>\n<path>\n<point lat=\"37.7798\"
+        lon=\"-122.49344\"/>\n<point lat=\"37.77967\" lon=\"-122.4964\"/>\n<point
+        lat=\"37.77947\" lon=\"-122.50068\"/>\n<point lat=\"37.77935\" lon=\"-122.5008\"/>\n<point
+        lat=\"37.7796499\" lon=\"-122.50285\"/>\n<point lat=\"37.77984\" lon=\"-122.50501\"/>\n<point
+        lat=\"37.77998\" lon=\"-122.5073\"/>\n<point lat=\"37.78004\" lon=\"-122.50744\"/>\n<point
+        lat=\"37.77985\" lon=\"-122.50943\"/>\n<point lat=\"37.77902\" lon=\"-122.50941\"/>\n</path>\n<path>\n<point
+        lat=\"37.77902\" lon=\"-122.50941\"/>\n<point lat=\"37.77904\" lon=\"-122.50626\"/>\n<point
+        lat=\"37.77915\" lon=\"-122.50277\"/>\n<point lat=\"37.77929\" lon=\"-122.49983\"/>\n<point
+        lat=\"37.77944\" lon=\"-122.49662\"/>\n<point lat=\"37.77957\" lon=\"-122.4934\"/>\n</path>\n<path>\n<point
+        lat=\"37.77957\" lon=\"-122.49338\"/>\n<point lat=\"37.7778599\" lon=\"-122.49325\"/>\n<point
+        lat=\"37.776\" lon=\"-122.49313\"/>\n<point lat=\"37.77591\" lon=\"-122.49304\"/>\n<point
+        lat=\"37.77596\" lon=\"-122.49196\"/>\n<point lat=\"37.77668\" lon=\"-122.49195\"/>\n</path>\n<path>\n<point
+        lat=\"37.77957\" lon=\"-122.4934\"/>\n<point lat=\"37.7796499\" lon=\"-122.49207\"/>\n<point
+        lat=\"37.77973\" lon=\"-122.49019\"/>\n<point lat=\"37.77986\" lon=\"-122.48805\"/>\n<point
+        lat=\"37.77998\" lon=\"-122.48482\"/>\n<point lat=\"37.78008\" lon=\"-122.48269\"/>\n<point
+        lat=\"37.78022\" lon=\"-122.47948\"/>\n<point lat=\"37.78037\" lon=\"-122.47626\"/>\n<point
+        lat=\"37.78053\" lon=\"-122.47268\"/>\n</path>\n</route>\n</body>\n"
+    http_version: 
+  recorded_at: Tue, 26 Mar 2013 19:41:23 GMT
+- request:
+    method: get
+    uri: http://webservices.nextbus.com/service/publicXMLFeed?a=sf-muni&command=predictions&d=38_IB3&r=38&s=15511
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - '*/*'
+      User-Agent:
+      - Ruby
+      Host:
+      - webservices.nextbus.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 Mar 2013 19:41:23 GMT
+      Server:
+      - Apache/2.2.4 (Unix) mod_ssl/2.2.4 OpenSSL/0.9.7m DAV/2 mod_jk/1.2.30
+      Access-Control-Allow-Origin:
+      - '*'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '424'
+      Content-Type:
+      - text/xml
+      X-Pad:
+      - avoid browser bug
+    body:
+      encoding: UTF-8
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\" ?> \n<body copyright=\"All
+        data copyright San Francisco Muni 2013.\">\n<predictions agencyTitle=\"San
+        Francisco Muni\" routeTitle=\"38-Geary\" routeTag=\"38\" stopTitle=\"Fort
+        Miley Hospital\" stopTag=\"15511\">\n  <direction title=\"Inbound to Downtown\">\n
+        \ <prediction epochTime=\"1364327460000\" seconds=\"576\" minutes=\"9\" isDeparture=\"true\"
+        affectedByLayover=\"true\" dirTag=\"38_IB3\" vehicle=\"6211\" block=\"3804\"
+        tripTag=\"5542018\" />\n  <prediction epochTime=\"1364328480000\" seconds=\"1596\"
+        minutes=\"26\" isDeparture=\"true\" affectedByLayover=\"true\" dirTag=\"38_IB3\"
+        vehicle=\"6231\" block=\"3805\" tripTag=\"5542020\" />\n  <prediction epochTime=\"1364329440000\"
+        seconds=\"2556\" minutes=\"42\" isDeparture=\"true\" affectedByLayover=\"true\"
+        dirTag=\"38_IB3\" vehicle=\"6282\" block=\"3813\" tripTag=\"5542022\" />\n
+        \ <prediction epochTime=\"1364330400000\" seconds=\"3516\" minutes=\"58\"
+        isDeparture=\"true\" affectedByLayover=\"true\" dirTag=\"38_IB3\" vehicle=\"6240\"
+        block=\"3807\" tripTag=\"5542024\" />\n  <prediction epochTime=\"1364331360000\"
+        seconds=\"4476\" minutes=\"74\" isDeparture=\"true\" affectedByLayover=\"true\"
+        dirTag=\"38_IB3\" vehicle=\"6214\" block=\"3809\" tripTag=\"5542026\" />\n
+        \ </direction>\n</predictions>\n</body>\n"
+    http_version: 
+  recorded_at: Tue, 26 Mar 2013 19:41:23 GMT
+- request:
+    method: get
+    uri: http://webservices.nextbus.com/service/publicXMLFeed?a=sf-muni&command=predictions&d=38_IB3&r=38&s=15511
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - '*/*'
+      User-Agent:
+      - Ruby
+      Host:
+      - webservices.nextbus.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 Mar 2013 19:41:23 GMT
+      Server:
+      - Apache/2.2.4 (Unix) mod_ssl/2.2.4 OpenSSL/0.9.7m DAV/2 mod_jk/1.2.30
+      Access-Control-Allow-Origin:
+      - '*'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '424'
+      Content-Type:
+      - text/xml
+      X-Pad:
+      - avoid browser bug
+    body:
+      encoding: UTF-8
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\" ?> \n<body copyright=\"All
+        data copyright San Francisco Muni 2013.\">\n<predictions agencyTitle=\"San
+        Francisco Muni\" routeTitle=\"38-Geary\" routeTag=\"38\" stopTitle=\"Fort
+        Miley Hospital\" stopTag=\"15511\">\n  <direction title=\"Inbound to Downtown\">\n
+        \ <prediction epochTime=\"1364327460000\" seconds=\"576\" minutes=\"9\" isDeparture=\"true\"
+        affectedByLayover=\"true\" dirTag=\"38_IB3\" vehicle=\"6211\" block=\"3804\"
+        tripTag=\"5542018\" />\n  <prediction epochTime=\"1364328480000\" seconds=\"1596\"
+        minutes=\"26\" isDeparture=\"true\" affectedByLayover=\"true\" dirTag=\"38_IB3\"
+        vehicle=\"6231\" block=\"3805\" tripTag=\"5542020\" />\n  <prediction epochTime=\"1364329440000\"
+        seconds=\"2556\" minutes=\"42\" isDeparture=\"true\" affectedByLayover=\"true\"
+        dirTag=\"38_IB3\" vehicle=\"6282\" block=\"3813\" tripTag=\"5542022\" />\n
+        \ <prediction epochTime=\"1364330400000\" seconds=\"3516\" minutes=\"58\"
+        isDeparture=\"true\" affectedByLayover=\"true\" dirTag=\"38_IB3\" vehicle=\"6240\"
+        block=\"3807\" tripTag=\"5542024\" />\n  <prediction epochTime=\"1364331360000\"
+        seconds=\"4476\" minutes=\"74\" isDeparture=\"true\" affectedByLayover=\"true\"
+        dirTag=\"38_IB3\" vehicle=\"6214\" block=\"3809\" tripTag=\"5542026\" />\n
+        \ </direction>\n</predictions>\n</body>\n"
+    http_version: 
+  recorded_at: Tue, 26 Mar 2013 19:41:23 GMT
+recorded_with: VCR 2.4.0

--- a/spec/cassettes/Muni_Stop/_predictions/should_return_an_empty_array_if_there_are_no_predictions.yml
+++ b/spec/cassettes/Muni_Stop/_predictions/should_return_an_empty_array_if_there_are_no_predictions.yml
@@ -1,0 +1,368 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://webservices.nextbus.com/service/publicXMLFeed?a=sf-muni&command=routeConfig&r=38
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - '*/*'
+      User-Agent:
+      - Ruby
+      Host:
+      - webservices.nextbus.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 Mar 2013 19:41:24 GMT
+      Server:
+      - Apache/2.2.4 (Unix) mod_ssl/2.2.4 OpenSSL/0.9.7m DAV/2 mod_jk/1.2.30
+      Access-Control-Allow-Origin:
+      - '*'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '3682'
+      Content-Type:
+      - text/xml
+      X-Pad:
+      - avoid browser bug
+    body:
+      encoding: UTF-8
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\" ?> \n<body copyright=\"All
+        data copyright San Francisco Muni 2013.\">\n<route tag=\"38\" title=\"38-Geary\"
+        color=\"ff6633\" oppositeColor=\"000000\" latMin=\"37.7759999\" latMax=\"37.7917499\"
+        lonMin=\"-122.50941\" lonMax=\"-122.3933\">\n<stop tag=\"7620\" title=\"Main
+        St &amp; Howard St\" lat=\"37.7905499\" lon=\"-122.3933\" stopId=\"17620\"/>\n<stop
+        tag=\"5579\" title=\"Mission St &amp; Beale St\" lat=\"37.7911399\" lon=\"-122.39592\"
+        stopId=\"15579\"/>\n<stop tag=\"4725\" title=\"Fremont St &amp; Market St\"
+        lat=\"37.7916499\" lon=\"-122.3981499\" stopId=\"14725\"/>\n<stop tag=\"5689\"
+        title=\"Market St &amp; Sansome St\" lat=\"37.79016\" lon=\"-122.4004099\"
+        stopId=\"15689\"/>\n<stop tag=\"5684\" title=\"Market St &amp; Montgomery
+        St\" lat=\"37.7884899\" lon=\"-122.40248\" stopId=\"15684\"/>\n<stop tag=\"4301\"
+        title=\"Geary Blvd &amp; Kearny St\" lat=\"37.7879999\" lon=\"-122.4036599\"
+        stopId=\"14301\"/>\n<stop tag=\"4766\" title=\"Geary Blvd &amp; Stockton St\"
+        lat=\"37.78764\" lon=\"-122.4064899\" stopId=\"14766\"/>\n<stop tag=\"4757\"
+        title=\"Geary Blvd &amp; Powell St\" lat=\"37.7873999\" lon=\"-122.40839\"
+        stopId=\"14757\"/>\n<stop tag=\"4767\" title=\"Geary Blvd &amp; Taylor St\"
+        lat=\"37.78698\" lon=\"-122.4116799\" stopId=\"14767\"/>\n<stop tag=\"4300\"
+        title=\"Geary Blvd &amp; Jones St\" lat=\"37.78677\" lon=\"-122.4133299\"
+        stopId=\"14300\"/>\n<stop tag=\"4303\" title=\"Geary Blvd &amp; Leavenworth
+        St\" lat=\"37.78656\" lon=\"-122.4149699\" stopId=\"14303\"/>\n<stop tag=\"4299\"
+        title=\"Geary Blvd &amp; Hyde St\" lat=\"37.78635\" lon=\"-122.4166099\" stopId=\"14299\"/>\n<stop
+        tag=\"4302\" title=\"Geary Blvd &amp; Larkin St\" lat=\"37.7861399\" lon=\"-122.41825\"
+        stopId=\"14302\"/>\n<stop tag=\"4768\" title=\"Geary Blvd &amp; Van Ness Ave\"
+        lat=\"37.7858399\" lon=\"-122.42063\" stopId=\"14768\"/>\n<stop tag=\"4297\"
+        title=\"Geary Blvd &amp; Franklin St\" lat=\"37.7855699\" lon=\"-122.42289\"
+        stopId=\"14297\"/>\n<stop tag=\"4298\" title=\"Geary Blvd &amp; Gough St\"
+        lat=\"37.7854299\" lon=\"-122.4250799\" stopId=\"14298\"/>\n<stop tag=\"4304\"
+        title=\"Geary Blvd &amp; Laguna St\" lat=\"37.78503\" lon=\"-122.4278099\"
+        stopId=\"14304\"/>\n<stop tag=\"4769\" title=\"Geary Blvd &amp; Webster St\"
+        lat=\"37.7846399\" lon=\"-122.43102\" stopId=\"14769\"/>\n<stop tag=\"4295\"
+        title=\"Geary Blvd &amp; Fillmore St\" lat=\"37.7843899\" lon=\"-122.43305\"
+        stopId=\"14295\"/>\n<stop tag=\"4760\" title=\"Geary Blvd &amp; Scott St\"
+        lat=\"37.78385\" lon=\"-122.4377599\" stopId=\"14760\"/>\n<stop tag=\"4293\"
+        title=\"Geary Blvd &amp; Divisadero St\" lat=\"37.78343\" lon=\"-122.4393699\"
+        stopId=\"14293\"/>\n<stop tag=\"4289\" title=\"Geary Blvd &amp; Baker St\"
+        lat=\"37.7829699\" lon=\"-122.44296\" stopId=\"14289\"/>\n<stop tag=\"4758\"
+        title=\"Geary Blvd &amp; Presidio Ave\" lat=\"37.7825099\" lon=\"-122.4468\"
+        stopId=\"14758\"/>\n<stop tag=\"4290\" title=\"Geary Blvd &amp; Collins St\"
+        lat=\"37.78224\" lon=\"-122.4499899\" stopId=\"14290\"/>\n<stop tag=\"4762\"
+        title=\"Geary Blvd &amp; Spruce St\" lat=\"37.7818499\" lon=\"-122.45307\"
+        stopId=\"14762\"/>\n<stop tag=\"4292\" title=\"Geary Blvd &amp; Commonwealth
+        St\" lat=\"37.7815299\" lon=\"-122.45568\" stopId=\"14292\"/>\n<stop tag=\"4287\"
+        title=\"Geary Blvd &amp; Arguello Blvd\" lat=\"37.7813799\" lon=\"-122.45874\"
+        stopId=\"14287\"/>\n<stop tag=\"4255\" title=\"Geary Blvd &amp; 3rd Ave\"
+        lat=\"37.78128\" lon=\"-122.4609399\" stopId=\"14255\"/>\n<stop tag=\"4257\"
+        title=\"Geary Blvd &amp; 6th Ave\" lat=\"37.7811299\" lon=\"-122.46416\" stopId=\"14257\"/>\n<stop
+        tag=\"4259\" title=\"Geary Blvd &amp; 9th Ave\" lat=\"37.78098\" lon=\"-122.4676399\"
+        stopId=\"14259\"/>\n<stop tag=\"4261\" title=\"Geary Blvd &amp; 12th Ave\"
+        lat=\"37.78084\" lon=\"-122.4705999\" stopId=\"14261\"/>\n<stop tag=\"4755\"
+        title=\"Geary Blvd &amp; Park Presidio Blvd\" lat=\"37.7806899\" lon=\"-122.47242\"
+        stopId=\"14755\"/>\n<stop tag=\"4263\" title=\"Geary Blvd &amp; 17th Ave\"
+        lat=\"37.7805999\" lon=\"-122.47604\" stopId=\"14263\"/>\n<stop tag=\"4265\"
+        title=\"Geary Blvd &amp; 20th Ave\" lat=\"37.78045\" lon=\"-122.4792699\"
+        stopId=\"14265\"/>\n<stop tag=\"4267\" title=\"Geary Blvd &amp; 22nd Ave\"
+        lat=\"37.78035\" lon=\"-122.4813999\" stopId=\"14267\"/>\n<stop tag=\"4269\"
+        title=\"Geary Blvd &amp; 25th Ave\" lat=\"37.7802199\" lon=\"-122.48461\"
+        stopId=\"14269\"/>\n<stop tag=\"4271\" title=\"Geary Blvd &amp; 28th Ave\"
+        lat=\"37.7800099\" lon=\"-122.48781\" stopId=\"14271\"/>\n<stop tag=\"4273\"
+        title=\"Geary Blvd &amp; 30th Ave\" lat=\"37.7799599\" lon=\"-122.48997\"
+        stopId=\"14273\"/>\n<stop tag=\"3560\" title=\"33rd Ave &amp; Geary Blvd\"
+        lat=\"37.7795699\" lon=\"-122.49338\" stopId=\"13560\"/>\n<stop tag=\"3551\"
+        title=\"33rd Ave &amp; Anza St\" lat=\"37.77786\" lon=\"-122.49325\" stopId=\"13551\"/>\n<stop
+        tag=\"3554\" title=\"33rd Ave &amp; Balboa St\" lat=\"37.7759999\" lon=\"-122.4931299\"
+        stopId=\"13554\"/>\n<stop tag=\"33545\" title=\"32nd Ave &amp; Balboa St\"
+        lat=\"37.7766799\" lon=\"-122.49195\" stopId=\"133545\"/>\n<stop tag=\"4278\"
+        title=\"Geary Blvd &amp; 33rd Ave\" lat=\"37.7797999\" lon=\"-122.49344\"
+        stopId=\"14278\"/>\n<stop tag=\"4280\" title=\"Geary Blvd &amp; 36th Ave\"
+        lat=\"37.7796699\" lon=\"-122.4964\" stopId=\"14280\"/>\n<stop tag=\"4282\"
+        title=\"Geary Blvd &amp; 40th Ave\" lat=\"37.7794699\" lon=\"-122.50068\"
+        stopId=\"14282\"/>\n<stop tag=\"6109\" title=\"Point Lobos Ave &amp; 42nd
+        Ave\" lat=\"37.7796499\" lon=\"-122.5028499\" stopId=\"16109\"/>\n<stop tag=\"3566\"
+        title=\"42nd Ave &amp; Clement St\" lat=\"37.7810899\" lon=\"-122.5029899\"
+        stopId=\"13566\"/>\n<stop tag=\"5511\" title=\"Fort Miley Hospital\" lat=\"37.7818299\"
+        lon=\"-122.50411\" stopId=\"15511\"/>\n<stop tag=\"3567\" title=\"43rd Ave
+        &amp; Clement St\" lat=\"37.78101\" lon=\"-122.5042299\" stopId=\"13567\"/>\n<stop
+        tag=\"3568\" title=\"43rd Ave &amp; Point Lobos Ave\" lat=\"37.7797799\" lon=\"-122.5041399\"
+        stopId=\"13568\"/>\n<stop tag=\"6111\" title=\"Point Lobos Ave &amp; 44th
+        Ave\" lat=\"37.77984\" lon=\"-122.50501\" stopId=\"16111\"/>\n<stop tag=\"6129\"
+        title=\"Point Lobos Ave &amp; 46th Ave\" lat=\"37.7800399\" lon=\"-122.50744\"
+        stopId=\"16129\"/>\n<stop tag=\"33608\" title=\"48th Ave &amp; Point Lobos
+        Ave\" lat=\"37.7790199\" lon=\"-122.50941\" stopId=\"133608\"/>\n<stop tag=\"35511\"
+        title=\"Fort Miley Hospital\" lat=\"37.7818299\" lon=\"-122.50411\" stopId=\"135511\"/>\n<stop
+        tag=\"3545\" title=\"32nd Ave &amp; Balboa St\" lat=\"37.7766799\" lon=\"-122.49195\"
+        stopId=\"13545\"/>\n<stop tag=\"3635\" title=\"Anza St &amp; 33rd Ave\" lat=\"37.7778499\"
+        lon=\"-122.4930299\" stopId=\"13635\"/>\n<stop tag=\"3559\" title=\"33rd Ave
+        &amp; Geary Blvd\" lat=\"37.7795499\" lon=\"-122.49321\" stopId=\"13559\"/>\n<stop
+        tag=\"4275\" title=\"Geary Blvd &amp; 32nd Ave\" lat=\"37.77965\" lon=\"-122.4920699\"
+        stopId=\"14275\"/>\n<stop tag=\"4274\" title=\"Geary Blvd &amp; 30th Ave\"
+        lat=\"37.77973\" lon=\"-122.4901899\" stopId=\"14274\"/>\n<stop tag=\"4272\"
+        title=\"Geary Blvd &amp; 28th Ave\" lat=\"37.7798599\" lon=\"-122.48805\"
+        stopId=\"14272\"/>\n<stop tag=\"4270\" title=\"Geary Blvd &amp; 25th Ave\"
+        lat=\"37.7799799\" lon=\"-122.48482\" stopId=\"14270\"/>\n<stop tag=\"4268\"
+        title=\"Geary Blvd &amp; 23rd Ave\" lat=\"37.78008\" lon=\"-122.4826899\"
+        stopId=\"14268\"/>\n<stop tag=\"4266\" title=\"Geary Blvd &amp; 20th Ave\"
+        lat=\"37.7802199\" lon=\"-122.47948\" stopId=\"14266\"/>\n<stop tag=\"4264\"
+        title=\"Geary Blvd &amp; 17th Ave\" lat=\"37.78037\" lon=\"-122.4762599\"
+        stopId=\"14264\"/>\n<stop tag=\"4756\" title=\"Geary Blvd &amp; Park Presidio
+        Blvd\" lat=\"37.7805299\" lon=\"-122.47268\" stopId=\"14756\"/>\n<stop tag=\"4262\"
+        title=\"Geary Blvd &amp; 12th Ave\" lat=\"37.7806099\" lon=\"-122.47082\"
+        stopId=\"14262\"/>\n<stop tag=\"4260\" title=\"Geary Blvd &amp; 9th Ave\"
+        lat=\"37.78078\" lon=\"-122.4673199\" stopId=\"14260\"/>\n<stop tag=\"4258\"
+        title=\"Geary Blvd &amp; 6th Ave\" lat=\"37.7808999\" lon=\"-122.46438\" stopId=\"14258\"/>\n<stop
+        tag=\"4256\" title=\"Geary Blvd &amp; 3rd Ave\" lat=\"37.78105\" lon=\"-122.4611599\"
+        stopId=\"14256\"/>\n<stop tag=\"4288\" title=\"Geary Blvd &amp; Arguello Blvd\"
+        lat=\"37.7811499\" lon=\"-122.45869\" stopId=\"14288\"/>\n<stop tag=\"4764\"
+        title=\"Geary Blvd &amp; Stanyan St\" lat=\"37.7812599\" lon=\"-122.45643\"
+        stopId=\"14764\"/>\n<stop tag=\"4763\" title=\"Geary Blvd &amp; Spruce St\"
+        lat=\"37.7816\" lon=\"-122.4532599\" stopId=\"14763\"/>\n<stop tag=\"4291\"
+        title=\"Geary Blvd &amp; Collins St\" lat=\"37.78203\" lon=\"-122.4499099\"
+        stopId=\"14291\"/>\n<stop tag=\"4754\" title=\"Geary Blvd &amp; Masonic Ave\"
+        lat=\"37.78223\" lon=\"-122.4476299\" stopId=\"14754\"/>\n<stop tag=\"4759\"
+        title=\"Geary Blvd &amp; Presidio Ave\" lat=\"37.7823199\" lon=\"-122.44593\"
+        stopId=\"14759\"/>\n<stop tag=\"4765\" title=\"Geary Blvd &amp; St Joseph&apos;S
+        Ave\" lat=\"37.7828\" lon=\"-122.4425399\" stopId=\"14765\"/>\n<stop tag=\"4294\"
+        title=\"Geary Blvd &amp; Divisadero St\" lat=\"37.7831799\" lon=\"-122.43957\"
+        stopId=\"14294\"/>\n<stop tag=\"4761\" title=\"Geary Blvd &amp; Scott St\"
+        lat=\"37.78362\" lon=\"-122.4376699\" stopId=\"14761\"/>\n<stop tag=\"4296\"
+        title=\"Geary Blvd &amp; Fillmore St\" lat=\"37.7842599\" lon=\"-122.43331\"
+        stopId=\"14296\"/>\n<stop tag=\"4770\" title=\"Geary Blvd &amp; Webster St\"
+        lat=\"37.7844899\" lon=\"-122.43135\" stopId=\"14770\"/>\n<stop tag=\"4305\"
+        title=\"Geary Blvd &amp; Laguna St\" lat=\"37.78485\" lon=\"-122.4281499\"
+        stopId=\"14305\"/>\n<stop tag=\"6425\" title=\"Starr King Way &amp; Gough
+        St\" lat=\"37.7850499\" lon=\"-122.4240799\" stopId=\"16425\"/>\n<stop tag=\"5818\"
+        title=\"O&apos;Farrell St &amp; Van Ness Ave\" lat=\"37.7846599\" lon=\"-122.42141\"
+        stopId=\"15818\"/>\n<stop tag=\"5813\" title=\"O&apos;Farrell St &amp; Larkin
+        St\" lat=\"37.78509\" lon=\"-122.4179999\" stopId=\"15813\"/>\n<stop tag=\"5811\"
+        title=\"O&apos;Farrell St &amp; Hyde St\" lat=\"37.78537\" lon=\"-122.4157699\"
+        stopId=\"15811\"/>\n<stop tag=\"5814\" title=\"O&apos;Farrell St &amp; Leavenworth
+        St\" lat=\"37.78554\" lon=\"-122.4144399\" stopId=\"15814\"/>\n<stop tag=\"7301\"
+        title=\"O&apos;Farrell St &amp; Taylor St\" lat=\"37.7858499\" lon=\"-122.41198\"
+        stopId=\"17301\"/>\n<stop tag=\"5817\" title=\"O&apos;Farrell St &amp; Powell
+        St\" lat=\"37.7863299\" lon=\"-122.40813\" stopId=\"15817\"/>\n<stop tag=\"5810\"
+        title=\"O&apos;Farrell St &amp; Grant Ave\" lat=\"37.7866399\" lon=\"-122.40563\"
+        stopId=\"15810\"/>\n<stop tag=\"5641\" title=\"Market St &amp; 3rd St\" lat=\"37.7877099\"
+        lon=\"-122.40321\" stopId=\"15641\"/>\n<stop tag=\"5638\" title=\"Market St
+        &amp; 1st St\" lat=\"37.7909\" lon=\"-122.3991399\" stopId=\"15638\"/>\n<stop
+        tag=\"3089\" title=\"Beale St &amp; Mission St\" lat=\"37.7917499\" lon=\"-122.3966999\"
+        stopId=\"13089\"/>\n<stop tag=\"7619\" title=\"Bealemst &amp; Howard St\"
+        lat=\"37.78969\" lon=\"-122.39404\" stopId=\"17619\"/>\n<stop tag=\"3608\"
+        title=\"48th Ave &amp; Point Lobos Ave\" lat=\"37.7790199\" lon=\"-122.50941\"
+        stopId=\"13608\"/>\n<stop tag=\"4286\" title=\"Geary Blvd &amp; 45th Ave\"
+        lat=\"37.7790399\" lon=\"-122.50626\" stopId=\"14286\"/>\n<stop tag=\"4285\"
+        title=\"Geary Blvd &amp; 42nd Ave\" lat=\"37.77915\" lon=\"-122.5027699\"
+        stopId=\"14285\"/>\n<stop tag=\"4283\" title=\"Geary Blvd &amp; 39th Ave\"
+        lat=\"37.7792899\" lon=\"-122.49983\" stopId=\"14283\"/>\n<stop tag=\"4281\"
+        title=\"Geary Blvd &amp; 36th Ave\" lat=\"37.77944\" lon=\"-122.4966199\"
+        stopId=\"14281\"/>\n<stop tag=\"4279\" title=\"Geary Blvd &amp; 33rd Ave\"
+        lat=\"37.7795699\" lon=\"-122.4934\" stopId=\"14279\"/>\n<stop tag=\"15511\"
+        title=\"Fort Miley Hospital\" lat=\"37.7818299\" lon=\"-122.50411\" stopId=\"115511\"/>\n<stop
+        tag=\"13567\" title=\"43rd Ave &amp; Clement St\" lat=\"37.78101\" lon=\"-122.5042299\"
+        stopId=\"113567\"/>\n<stop tag=\"13568\" title=\"43rd Ave &amp; Point Lobos
+        Ave\" lat=\"37.7797799\" lon=\"-122.5041399\" stopId=\"113568\"/>\n<direction
+        tag=\"38_IB3\" title=\"Inbound to Downtown\" name=\"Inbound\" useForUI=\"true\">\n
+        \ <stop tag=\"15511\" />\n  <stop tag=\"13567\" />\n  <stop tag=\"13568\"
+        />\n  <stop tag=\"4285\" />\n  <stop tag=\"4283\" />\n  <stop tag=\"4281\"
+        />\n  <stop tag=\"4279\" />\n  <stop tag=\"4275\" />\n  <stop tag=\"4274\"
+        />\n  <stop tag=\"4272\" />\n  <stop tag=\"4270\" />\n  <stop tag=\"4268\"
+        />\n  <stop tag=\"4266\" />\n  <stop tag=\"4264\" />\n  <stop tag=\"4756\"
+        />\n  <stop tag=\"4262\" />\n  <stop tag=\"4260\" />\n  <stop tag=\"4258\"
+        />\n  <stop tag=\"4256\" />\n  <stop tag=\"4288\" />\n  <stop tag=\"4764\"
+        />\n  <stop tag=\"4763\" />\n  <stop tag=\"4291\" />\n  <stop tag=\"4754\"
+        />\n  <stop tag=\"4759\" />\n  <stop tag=\"4765\" />\n  <stop tag=\"4294\"
+        />\n  <stop tag=\"4761\" />\n  <stop tag=\"4296\" />\n  <stop tag=\"4770\"
+        />\n  <stop tag=\"4305\" />\n  <stop tag=\"6425\" />\n  <stop tag=\"5818\"
+        />\n  <stop tag=\"5813\" />\n  <stop tag=\"5811\" />\n  <stop tag=\"5814\"
+        />\n  <stop tag=\"7301\" />\n  <stop tag=\"5817\" />\n  <stop tag=\"5810\"
+        />\n  <stop tag=\"5641\" />\n  <stop tag=\"5638\" />\n  <stop tag=\"3089\"
+        />\n  <stop tag=\"7619\" />\n</direction>\n<direction tag=\"38_IB2\" title=\"Inbound
+        to Downtown\" name=\"Inbound\" useForUI=\"true\">\n  <stop tag=\"3608\" />\n
+        \ <stop tag=\"4286\" />\n  <stop tag=\"4285\" />\n  <stop tag=\"4283\" />\n
+        \ <stop tag=\"4281\" />\n  <stop tag=\"4279\" />\n  <stop tag=\"4275\" />\n
+        \ <stop tag=\"4274\" />\n  <stop tag=\"4272\" />\n  <stop tag=\"4270\" />\n
+        \ <stop tag=\"4268\" />\n  <stop tag=\"4266\" />\n  <stop tag=\"4264\" />\n
+        \ <stop tag=\"4756\" />\n  <stop tag=\"4262\" />\n  <stop tag=\"4260\" />\n
+        \ <stop tag=\"4258\" />\n  <stop tag=\"4256\" />\n  <stop tag=\"4288\" />\n
+        \ <stop tag=\"4764\" />\n  <stop tag=\"4763\" />\n  <stop tag=\"4291\" />\n
+        \ <stop tag=\"4754\" />\n  <stop tag=\"4759\" />\n  <stop tag=\"4765\" />\n
+        \ <stop tag=\"4294\" />\n  <stop tag=\"4761\" />\n  <stop tag=\"4296\" />\n
+        \ <stop tag=\"4770\" />\n  <stop tag=\"4305\" />\n  <stop tag=\"6425\" />\n
+        \ <stop tag=\"5818\" />\n  <stop tag=\"5813\" />\n  <stop tag=\"5811\" />\n
+        \ <stop tag=\"5814\" />\n  <stop tag=\"7301\" />\n  <stop tag=\"5817\" />\n
+        \ <stop tag=\"5810\" />\n  <stop tag=\"5641\" />\n  <stop tag=\"5638\" />\n
+        \ <stop tag=\"3089\" />\n  <stop tag=\"7619\" />\n</direction>\n<direction
+        tag=\"38_IB1\" title=\"Inbound to Downtown\" name=\"Inbound\" useForUI=\"true\">\n
+        \ <stop tag=\"3545\" />\n  <stop tag=\"3635\" />\n  <stop tag=\"3559\" />\n
+        \ <stop tag=\"4275\" />\n  <stop tag=\"4274\" />\n  <stop tag=\"4272\" />\n
+        \ <stop tag=\"4270\" />\n  <stop tag=\"4268\" />\n  <stop tag=\"4266\" />\n
+        \ <stop tag=\"4264\" />\n  <stop tag=\"4756\" />\n  <stop tag=\"4262\" />\n
+        \ <stop tag=\"4260\" />\n  <stop tag=\"4258\" />\n  <stop tag=\"4256\" />\n
+        \ <stop tag=\"4288\" />\n  <stop tag=\"4764\" />\n  <stop tag=\"4763\" />\n
+        \ <stop tag=\"4291\" />\n  <stop tag=\"4754\" />\n  <stop tag=\"4759\" />\n
+        \ <stop tag=\"4765\" />\n  <stop tag=\"4294\" />\n  <stop tag=\"4761\" />\n
+        \ <stop tag=\"4296\" />\n  <stop tag=\"4770\" />\n  <stop tag=\"4305\" />\n
+        \ <stop tag=\"6425\" />\n  <stop tag=\"5818\" />\n  <stop tag=\"5813\" />\n
+        \ <stop tag=\"5811\" />\n  <stop tag=\"5814\" />\n  <stop tag=\"7301\" />\n
+        \ <stop tag=\"5817\" />\n  <stop tag=\"5810\" />\n  <stop tag=\"5641\" />\n
+        \ <stop tag=\"5638\" />\n  <stop tag=\"3089\" />\n  <stop tag=\"7619\" />\n</direction>\n<direction
+        tag=\"38_OB3\" title=\"Outbound to the Richmond District\" name=\"Outbound\"
+        useForUI=\"true\">\n  <stop tag=\"7620\" />\n  <stop tag=\"5579\" />\n  <stop
+        tag=\"4725\" />\n  <stop tag=\"5689\" />\n  <stop tag=\"5684\" />\n  <stop
+        tag=\"4301\" />\n  <stop tag=\"4766\" />\n  <stop tag=\"4757\" />\n  <stop
+        tag=\"4767\" />\n  <stop tag=\"4300\" />\n  <stop tag=\"4303\" />\n  <stop
+        tag=\"4299\" />\n  <stop tag=\"4302\" />\n  <stop tag=\"4768\" />\n  <stop
+        tag=\"4297\" />\n  <stop tag=\"4298\" />\n  <stop tag=\"4304\" />\n  <stop
+        tag=\"4769\" />\n  <stop tag=\"4295\" />\n  <stop tag=\"4760\" />\n  <stop
+        tag=\"4293\" />\n  <stop tag=\"4289\" />\n  <stop tag=\"4758\" />\n  <stop
+        tag=\"4290\" />\n  <stop tag=\"4762\" />\n  <stop tag=\"4292\" />\n  <stop
+        tag=\"4287\" />\n  <stop tag=\"4255\" />\n  <stop tag=\"4257\" />\n  <stop
+        tag=\"4259\" />\n  <stop tag=\"4261\" />\n  <stop tag=\"4755\" />\n  <stop
+        tag=\"4263\" />\n  <stop tag=\"4265\" />\n  <stop tag=\"4267\" />\n  <stop
+        tag=\"4269\" />\n  <stop tag=\"4271\" />\n  <stop tag=\"4273\" />\n  <stop
+        tag=\"4278\" />\n  <stop tag=\"4280\" />\n  <stop tag=\"4282\" />\n  <stop
+        tag=\"6109\" />\n  <stop tag=\"3566\" />\n  <stop tag=\"5511\" />\n  <stop
+        tag=\"3567\" />\n  <stop tag=\"3568\" />\n  <stop tag=\"6111\" />\n  <stop
+        tag=\"6129\" />\n  <stop tag=\"33608\" />\n</direction>\n<path>\n<point lat=\"37.78771\"
+        lon=\"-122.40321\"/>\n<point lat=\"37.7909\" lon=\"-122.39914\"/>\n<point
+        lat=\"37.7924099\" lon=\"-122.39738\"/>\n<point lat=\"37.79175\" lon=\"-122.3967\"/>\n<point
+        lat=\"37.78993\" lon=\"-122.39428\"/>\n<point lat=\"37.78969\" lon=\"-122.39404\"/>\n</path>\n<path>\n<point
+        lat=\"37.78584\" lon=\"-122.42063\"/>\n<point lat=\"37.78557\" lon=\"-122.42289\"/>\n<point
+        lat=\"37.78541\" lon=\"-122.42355\"/>\n<point lat=\"37.7854\" lon=\"-122.42444\"/>\n<point
+        lat=\"37.78543\" lon=\"-122.42508\"/>\n<point lat=\"37.78503\" lon=\"-122.42781\"/>\n<point
+        lat=\"37.78464\" lon=\"-122.43102\"/>\n<point lat=\"37.78439\" lon=\"-122.43305\"/>\n</path>\n<path>\n<point
+        lat=\"37.78053\" lon=\"-122.47268\"/>\n<point lat=\"37.78061\" lon=\"-122.47082\"/>\n<point
+        lat=\"37.78078\" lon=\"-122.46732\"/>\n<point lat=\"37.7809\" lon=\"-122.46438\"/>\n<point
+        lat=\"37.78105\" lon=\"-122.46116\"/>\n<point lat=\"37.7811499\" lon=\"-122.45869\"/>\n<point
+        lat=\"37.78126\" lon=\"-122.45643\"/>\n<point lat=\"37.7816\" lon=\"-122.45326\"/>\n<point
+        lat=\"37.78203\" lon=\"-122.44991\"/>\n<point lat=\"37.78229\" lon=\"-122.44789\"/>\n<point
+        lat=\"37.78223\" lon=\"-122.44763\"/>\n<point lat=\"37.7822699\" lon=\"-122.44754\"/>\n<point
+        lat=\"37.78222\" lon=\"-122.44723\"/>\n<point lat=\"37.78232\" lon=\"-122.44593\"/>\n</path>\n<path>\n<point
+        lat=\"37.78069\" lon=\"-122.47242\"/>\n<point lat=\"37.7806\" lon=\"-122.47604\"/>\n<point
+        lat=\"37.78045\" lon=\"-122.47927\"/>\n<point lat=\"37.78035\" lon=\"-122.4814\"/>\n<point
+        lat=\"37.78022\" lon=\"-122.48461\"/>\n<point lat=\"37.78001\" lon=\"-122.48781\"/>\n<point
+        lat=\"37.77996\" lon=\"-122.48997\"/>\n<point lat=\"37.7798\" lon=\"-122.49344\"/>\n</path>\n<path>\n<point
+        lat=\"37.78849\" lon=\"-122.40248\"/>\n<point lat=\"37.7880899\" lon=\"-122.4029\"/>\n<point
+        lat=\"37.78796\" lon=\"-122.40349\"/>\n<point lat=\"37.7879999\" lon=\"-122.40366\"/>\n<point
+        lat=\"37.78764\" lon=\"-122.40649\"/>\n<point lat=\"37.7874\" lon=\"-122.40839\"/>\n</path>\n<path>\n<point
+        lat=\"37.78426\" lon=\"-122.43331\"/>\n<point lat=\"37.78449\" lon=\"-122.43135\"/>\n<point
+        lat=\"37.78485\" lon=\"-122.42815\"/>\n<point lat=\"37.78534\" lon=\"-122.42469\"/>\n<point
+        lat=\"37.78519\" lon=\"-122.42417\"/>\n<point lat=\"37.78505\" lon=\"-122.42408\"/>\n<point
+        lat=\"37.7849999\" lon=\"-122.42387\"/>\n<point lat=\"37.78477\" lon=\"-122.42361\"/>\n<point
+        lat=\"37.7846199\" lon=\"-122.42332\"/>\n<point lat=\"37.78455\" lon=\"-122.42304\"/>\n<point
+        lat=\"37.78466\" lon=\"-122.42141\"/>\n</path>\n<path>\n<point lat=\"37.79055\"
+        lon=\"-122.3933\"/>\n<point lat=\"37.79184\" lon=\"-122.39494\"/>\n<point
+        lat=\"37.79114\" lon=\"-122.39592\"/>\n<point lat=\"37.79046\" lon=\"-122.39669\"/>\n<point
+        lat=\"37.79165\" lon=\"-122.39815\"/>\n<point lat=\"37.79172\" lon=\"-122.39826\"/>\n<point
+        lat=\"37.79016\" lon=\"-122.40041\"/>\n<point lat=\"37.78849\" lon=\"-122.40248\"/>\n</path>\n<path>\n<point
+        lat=\"37.78466\" lon=\"-122.42141\"/>\n<point lat=\"37.7850899\" lon=\"-122.418\"/>\n<point
+        lat=\"37.78537\" lon=\"-122.41577\"/>\n<point lat=\"37.78554\" lon=\"-122.41444\"/>\n<point
+        lat=\"37.78585\" lon=\"-122.41198\"/>\n<point lat=\"37.78633\" lon=\"-122.40813\"/>\n</path>\n<path>\n<point
+        lat=\"37.78251\" lon=\"-122.4468\"/>\n<point lat=\"37.78239\" lon=\"-122.4473\"/>\n<point
+        lat=\"37.78248\" lon=\"-122.44806\"/>\n<point lat=\"37.78224\" lon=\"-122.44999\"/>\n<point
+        lat=\"37.78185\" lon=\"-122.45307\"/>\n<point lat=\"37.7815299\" lon=\"-122.45568\"/>\n<point
+        lat=\"37.78138\" lon=\"-122.45874\"/>\n<point lat=\"37.78128\" lon=\"-122.46094\"/>\n<point
+        lat=\"37.78113\" lon=\"-122.46416\"/>\n<point lat=\"37.78098\" lon=\"-122.46764\"/>\n<point
+        lat=\"37.78084\" lon=\"-122.4706\"/>\n<point lat=\"37.78069\" lon=\"-122.47242\"/>\n</path>\n<path>\n<point
+        lat=\"37.78232\" lon=\"-122.44593\"/>\n<point lat=\"37.7828\" lon=\"-122.44254\"/>\n<point
+        lat=\"37.78318\" lon=\"-122.43957\"/>\n<point lat=\"37.78343\" lon=\"-122.43864\"/>\n<point
+        lat=\"37.78367\" lon=\"-122.43803\"/>\n<point lat=\"37.78362\" lon=\"-122.43767\"/>\n<point
+        lat=\"37.78426\" lon=\"-122.43331\"/>\n</path>\n<path>\n<point lat=\"37.78633\"
+        lon=\"-122.40813\"/>\n<point lat=\"37.78664\" lon=\"-122.40563\"/>\n<point
+        lat=\"37.78681\" lon=\"-122.40485\"/>\n<point lat=\"37.78673\" lon=\"-122.40458\"/>\n<point
+        lat=\"37.78771\" lon=\"-122.40321\"/>\n</path>\n<path>\n<point lat=\"37.7874\"
+        lon=\"-122.40839\"/>\n<point lat=\"37.78698\" lon=\"-122.41168\"/>\n<point
+        lat=\"37.78677\" lon=\"-122.41333\"/>\n<point lat=\"37.78656\" lon=\"-122.41497\"/>\n<point
+        lat=\"37.78635\" lon=\"-122.41661\"/>\n<point lat=\"37.78614\" lon=\"-122.41825\"/>\n<point
+        lat=\"37.78584\" lon=\"-122.42063\"/>\n</path>\n<path>\n<point lat=\"37.78183\"
+        lon=\"-122.50411\"/>\n<point lat=\"37.78197\" lon=\"-122.50458\"/>\n<point
+        lat=\"37.78202\" lon=\"-122.50492\"/>\n<point lat=\"37.78208\" lon=\"-122.50711\"/>\n<point
+        lat=\"37.78216\" lon=\"-122.50738\"/>\n<point lat=\"37.78195\" lon=\"-122.5076\"/>\n<point
+        lat=\"37.78173\" lon=\"-122.50739\"/>\n<point lat=\"37.78159\" lon=\"-122.50708\"/>\n<point
+        lat=\"37.7815299\" lon=\"-122.5067\"/>\n<point lat=\"37.78159\" lon=\"-122.50634\"/>\n<point
+        lat=\"37.7816\" lon=\"-122.506\"/>\n<point lat=\"37.78143\" lon=\"-122.5057\"/>\n<point
+        lat=\"37.78132\" lon=\"-122.50439\"/>\n<point lat=\"37.78113\" lon=\"-122.50416\"/>\n<point
+        lat=\"37.78101\" lon=\"-122.50423\"/>\n<point lat=\"37.77978\" lon=\"-122.50414\"/>\n<point
+        lat=\"37.77971\" lon=\"-122.50406\"/>\n<point lat=\"37.77984\" lon=\"-122.50501\"/>\n<point
+        lat=\"37.77998\" lon=\"-122.5073\"/>\n<point lat=\"37.78004\" lon=\"-122.50744\"/>\n<point
+        lat=\"37.77985\" lon=\"-122.50943\"/>\n<point lat=\"37.77902\" lon=\"-122.50941\"/>\n</path>\n<path>\n<point
+        lat=\"37.78069\" lon=\"-122.47242\"/>\n<point lat=\"37.7806\" lon=\"-122.47604\"/>\n<point
+        lat=\"37.78045\" lon=\"-122.47927\"/>\n<point lat=\"37.78035\" lon=\"-122.4814\"/>\n<point
+        lat=\"37.78022\" lon=\"-122.48461\"/>\n<point lat=\"37.78001\" lon=\"-122.48781\"/>\n<point
+        lat=\"37.77996\" lon=\"-122.48997\"/>\n<point lat=\"37.77969\" lon=\"-122.4933\"/>\n<point
+        lat=\"37.77957\" lon=\"-122.49338\"/>\n</path>\n<path>\n<point lat=\"37.78439\"
+        lon=\"-122.43305\"/>\n<point lat=\"37.78385\" lon=\"-122.43776\"/>\n<point
+        lat=\"37.78372\" lon=\"-122.43785\"/>\n<point lat=\"37.78343\" lon=\"-122.43864\"/>\n<point
+        lat=\"37.78343\" lon=\"-122.43937\"/>\n<point lat=\"37.78297\" lon=\"-122.44296\"/>\n<point
+        lat=\"37.78251\" lon=\"-122.4468\"/>\n</path>\n<path>\n<point lat=\"37.7798\"
+        lon=\"-122.49344\"/>\n<point lat=\"37.77967\" lon=\"-122.4964\"/>\n<point
+        lat=\"37.77947\" lon=\"-122.50068\"/>\n<point lat=\"37.77935\" lon=\"-122.5008\"/>\n<point
+        lat=\"37.7796499\" lon=\"-122.50285\"/>\n<point lat=\"37.77961\" lon=\"-122.50297\"/>\n<point
+        lat=\"37.78109\" lon=\"-122.50299\"/>\n<point lat=\"37.78118\" lon=\"-122.50309\"/>\n<point
+        lat=\"37.78139\" lon=\"-122.5032\"/>\n<point lat=\"37.78148\" lon=\"-122.50357\"/>\n<point
+        lat=\"37.78183\" lon=\"-122.50411\"/>\n</path>\n<path>\n<point lat=\"37.77955\"
+        lon=\"-122.49321\"/>\n<point lat=\"37.77969\" lon=\"-122.4933\"/>\n<point
+        lat=\"37.7796499\" lon=\"-122.49207\"/>\n<point lat=\"37.77973\" lon=\"-122.49019\"/>\n<point
+        lat=\"37.77986\" lon=\"-122.48805\"/>\n<point lat=\"37.77998\" lon=\"-122.48482\"/>\n<point
+        lat=\"37.78008\" lon=\"-122.48269\"/>\n<point lat=\"37.78022\" lon=\"-122.47948\"/>\n<point
+        lat=\"37.78037\" lon=\"-122.47626\"/>\n<point lat=\"37.78053\" lon=\"-122.47268\"/>\n</path>\n<path>\n<point
+        lat=\"37.78183\" lon=\"-122.50411\"/>\n<point lat=\"37.78197\" lon=\"-122.50458\"/>\n<point
+        lat=\"37.78202\" lon=\"-122.50492\"/>\n<point lat=\"37.78208\" lon=\"-122.50711\"/>\n<point
+        lat=\"37.78216\" lon=\"-122.50738\"/>\n<point lat=\"37.78195\" lon=\"-122.5076\"/>\n<point
+        lat=\"37.78173\" lon=\"-122.50739\"/>\n<point lat=\"37.78159\" lon=\"-122.50708\"/>\n<point
+        lat=\"37.7815299\" lon=\"-122.5067\"/>\n<point lat=\"37.78159\" lon=\"-122.50634\"/>\n<point
+        lat=\"37.7816\" lon=\"-122.506\"/>\n<point lat=\"37.78143\" lon=\"-122.5057\"/>\n<point
+        lat=\"37.78132\" lon=\"-122.50439\"/>\n<point lat=\"37.78113\" lon=\"-122.50416\"/>\n<point
+        lat=\"37.78101\" lon=\"-122.50423\"/>\n<point lat=\"37.77978\" lon=\"-122.50414\"/>\n<point
+        lat=\"37.77921\" lon=\"-122.50402\"/>\n<point lat=\"37.77915\" lon=\"-122.50277\"/>\n<point
+        lat=\"37.77929\" lon=\"-122.49983\"/>\n<point lat=\"37.77944\" lon=\"-122.49662\"/>\n<point
+        lat=\"37.77957\" lon=\"-122.4934\"/>\n</path>\n<path>\n<point lat=\"37.77668\"
+        lon=\"-122.49195\"/>\n<point lat=\"37.77782\" lon=\"-122.49209\"/>\n<point
+        lat=\"37.77785\" lon=\"-122.49303\"/>\n<point lat=\"37.7777699\" lon=\"-122.49317\"/>\n<point
+        lat=\"37.77955\" lon=\"-122.49321\"/>\n</path>\n<path>\n<point lat=\"37.7798\"
+        lon=\"-122.49344\"/>\n<point lat=\"37.77967\" lon=\"-122.4964\"/>\n<point
+        lat=\"37.77947\" lon=\"-122.50068\"/>\n<point lat=\"37.77935\" lon=\"-122.5008\"/>\n<point
+        lat=\"37.7796499\" lon=\"-122.50285\"/>\n<point lat=\"37.77984\" lon=\"-122.50501\"/>\n<point
+        lat=\"37.77998\" lon=\"-122.5073\"/>\n<point lat=\"37.78004\" lon=\"-122.50744\"/>\n<point
+        lat=\"37.77985\" lon=\"-122.50943\"/>\n<point lat=\"37.77902\" lon=\"-122.50941\"/>\n</path>\n<path>\n<point
+        lat=\"37.77902\" lon=\"-122.50941\"/>\n<point lat=\"37.77904\" lon=\"-122.50626\"/>\n<point
+        lat=\"37.77915\" lon=\"-122.50277\"/>\n<point lat=\"37.77929\" lon=\"-122.49983\"/>\n<point
+        lat=\"37.77944\" lon=\"-122.49662\"/>\n<point lat=\"37.77957\" lon=\"-122.4934\"/>\n</path>\n<path>\n<point
+        lat=\"37.77957\" lon=\"-122.49338\"/>\n<point lat=\"37.7778599\" lon=\"-122.49325\"/>\n<point
+        lat=\"37.776\" lon=\"-122.49313\"/>\n<point lat=\"37.77591\" lon=\"-122.49304\"/>\n<point
+        lat=\"37.77596\" lon=\"-122.49196\"/>\n<point lat=\"37.77668\" lon=\"-122.49195\"/>\n</path>\n<path>\n<point
+        lat=\"37.77957\" lon=\"-122.4934\"/>\n<point lat=\"37.7796499\" lon=\"-122.49207\"/>\n<point
+        lat=\"37.77973\" lon=\"-122.49019\"/>\n<point lat=\"37.77986\" lon=\"-122.48805\"/>\n<point
+        lat=\"37.77998\" lon=\"-122.48482\"/>\n<point lat=\"37.78008\" lon=\"-122.48269\"/>\n<point
+        lat=\"37.78022\" lon=\"-122.47948\"/>\n<point lat=\"37.78037\" lon=\"-122.47626\"/>\n<point
+        lat=\"37.78053\" lon=\"-122.47268\"/>\n</path>\n</route>\n</body>\n"
+    http_version: 
+  recorded_at: Tue, 26 Mar 2013 19:41:24 GMT
+recorded_with: VCR 2.4.0

--- a/spec/direction_spec.rb
+++ b/spec/direction_spec.rb
@@ -1,26 +1,33 @@
 require 'spec_helper'
 
-describe Muni::Direction do
-  use_vcr_cassette "Muni_Route"
-
-  let(:route) { Muni::Route.find(21) }
+describe Muni::Direction, vcr: true do
+  let(:route) { Muni::Route.find(24) }
 
   context "#stop_at" do
-    context "given  a stop tag" do
+    context "given a stop tag" do
       it "should return the corresponding stop" do
-        stop = route.inbound.stop_at("36497")
+        stop = route.inbound.stop_at("3520")
 
         stop.should be_present
-        stop.title.should == "Steuart St & Mission St"
+        stop.title.should == "26th St & Noe St"
       end
     end
 
-    context "given a stop title" do
+    context "given an exact stop title" do
       it "should return corresponding stop" do
-        stop  = route.inbound.stop_at("Hayes St & Shrader St")
+        stop = route.inbound.stop_at("26th St & Noe St")
 
         stop.should be_present
-        stop.title.should == "Hayes St & Shrader St"
+        stop.title.should == "26th St & Noe St"
+      end
+    end
+
+    context "given an inexact stop title" do
+      it "should return a corresponding stop" do
+        stop = route.inbound.stop_at("26th & Noe")
+        stop.should be_present
+        stop.title.should == "26th St & Noe St"
+        stop.tag.should == "3520"
       end
     end
   end

--- a/spec/route_spec.rb
+++ b/spec/route_spec.rb
@@ -1,8 +1,6 @@
 require 'spec_helper'
 
-describe Muni::Route do
-  use_vcr_cassette
-
+describe Muni::Route, vcr: true do
   it "fetches all available routes" do
     routes = Muni::Route.find(:all)
     routes.should_not be_empty

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,12 +3,9 @@ require 'muni'
 require 'vcr'
 
 VCR.configure do |c|
+  c.configure_rspec_metadata!
   c.cassette_library_dir = 'spec/cassettes'
   c.hook_into :webmock
   c.default_cassette_options = { :record => :new_episodes }
 end
 
-RSpec.configure do |config|
-  config.extend VCR::RSpec::Macros
-  config.expect_with(:rspec){ |c| c.syntax = [:should, :expect] }
-end

--- a/spec/stop_spec.rb
+++ b/spec/stop_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
-describe Muni::Stop do
-  use_vcr_cassette "Muni_Route"
+describe Muni::Stop, vcr: true do
   context '#predictions' do
     it 'fetches predictions' do
       route = Muni::Route.find("38")


### PR DESCRIPTION
Example:

2.0.0p0 :017 > r21.inbound.stop_at("3520")
 => #<Muni::Stop tag="3520", title="26th St & Noe St", lat="37.7482699", lon="37.7482699", stopId="37.7482699", route_tag="24", direction="24_IB1"> 

2.0.0p0 :015 > r21.inbound.stop_at("26th St & Noe St")
 => nil 
